### PR TITLE
executor: make executor server exits when error happens

### DIFF
--- a/cmd/executor/main.go
+++ b/cmd/executor/main.go
@@ -61,8 +61,11 @@ func main() {
 		syscall.SIGTERM,
 		syscall.SIGQUIT)
 	go func() {
-		sig := <-sc
-		log.L().Info("got signal to exit", zap.Stringer("signal", sig))
+		select {
+		case sig := <-sc:
+			log.L().Info("got signal to exit", zap.Stringer("signal", sig))
+		case <-server.CloseCh():
+		}
 		cancel()
 	}()
 	<-ctx.Done()

--- a/executor/runtime/task.go
+++ b/executor/runtime/task.go
@@ -28,7 +28,7 @@ type Record struct {
 }
 
 func (r *Record) String() string {
-	return fmt.Sprintf("flowID %s start %s end %s\n", r.flowID, r.start.String(), r.End.String())
+	return fmt.Sprintf("flowID %s start %s end %s payload: %v\n", r.flowID, r.start.String(), r.End.String(), r.Payload)
 }
 
 type Channel struct {


### PR DESCRIPTION
Two minor fixes
- Exit executor server when error happens, such as heartbeat timeout.
- Record payload in benchmark demo output.