### PR TITLE
master: check self etcd is leader before campaign leader

### DIFF
--- a/cmd/master/example1.toml
+++ b/cmd/master/example1.toml
@@ -2,6 +2,6 @@ master-addr = "127.0.0.1:10240"
 advertise-addr = "127.0.0.1:10240"
 [etcd]
 name = "server-master-1"
-data-dir = "/tmp/df/master"
+data-dir = "/tmp/df/master1"
 peer-urls = "127.0.0.1:8391"
 initial-cluster = "server-master-1=http://127.0.0.1:8391,server-master-2=http://127.0.0.1:8392"

--- a/master/campaign.go
+++ b/master/campaign.go
@@ -89,13 +89,14 @@ func (s *Server) leaderLoop(ctx context.Context) {
 	}
 }
 
+// nolint:unused
 func (s *Server) resign() {
 	s.resignFn()
 }
 
 func (s *Server) campaign(ctx context.Context, timeout time.Duration) error {
 	log.L().Info("start to campaign server master leader", zap.String("name", s.name()))
-	leaderCtx, resignFn, err := s.election.Campaign(ctx, s.member(), time.Second*5)
+	leaderCtx, resignFn, err := s.election.Campaign(ctx, s.member(), timeout)
 	switch err {
 	case nil:
 	case context.Canceled:

--- a/master/campaign.go
+++ b/master/campaign.go
@@ -3,41 +3,111 @@ package master
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/hanfei1991/microcosm/client"
+	"github.com/hanfei1991/microcosm/pkg/adapter"
 	"github.com/hanfei1991/microcosm/pkg/errors"
+	"github.com/hanfei1991/microcosm/pkg/etcdutils"
+	perrors "github.com/pingcap/errors"
 	"github.com/pingcap/tiflow/dm/pkg/log"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/mvcc/mvccpb"
 	"go.uber.org/zap"
 )
 
-func (s *Server) campaignLeaderLoop(ctx context.Context) error {
+func (s *Server) leaderLoop(ctx context.Context) {
+	retryInterval := time.Millisecond * 200
 	for {
-		err := s.reset(ctx)
-		if err != nil {
-			return err
-		}
-		leaderCtx, resignFn, err := s.election.Campaign(ctx, s.name())
-		switch err {
-		case nil:
-		case context.Canceled:
-			return ctx.Err()
+		select {
+		case <-ctx.Done():
+			return
 		default:
-			log.L().Warn("campaign leader failed", zap.Error(err))
-			return errors.Wrap(errors.ErrMasterCampaignLeader, err)
 		}
-		s.resignFn = resignFn
-		// TODO: if etcd leader is different with current server, resign current
-		// leader to keep them same
-		log.L().Info("campaign leader successfully", zap.String("server-id", s.name()))
-		cctx, cancel := context.WithCancel(leaderCtx)
-		err = s.runLeaderService(cctx)
-		cancel()
-		log.L().Info("leader resigned", zap.Error(err))
+		key, data, rev, err := etcdutils.GetLeader(ctx, s.etcdClient, adapter.MasterCampaignKey.Path())
+		if err != nil {
+			if perrors.Cause(err) == context.Canceled {
+				return
+			}
+			if !errors.ErrMasterNoLeader.Equal(err) {
+				log.L().Warn("get leader failed", zap.Error(err))
+				time.Sleep(retryInterval)
+				continue
+			}
+		}
+		var leader *Member
+		if len(data) > 0 {
+			leader = &Member{}
+			err = leader.Unmarshal(data)
+			if err != nil {
+				log.L().Warn("unexpected leader data", zap.Error(err))
+				time.Sleep(retryInterval)
+				continue
+			}
+			if leader.Name == s.name() {
+				// this server is already a leader, which indicates there is some
+				// stale information, just delete the leadership and campaign again.
+				log.L().Warn("found stale leader key, delete it and campaign later",
+					zap.ByteString("key", key), zap.ByteString("val", data))
+				_, err := s.etcdClient.Delete(ctx, string(key))
+				if err != nil {
+					log.L().Error("failed to delete leader key",
+						zap.ByteString("key", key), zap.ByteString("val", data))
+				}
+				time.Sleep(retryInterval)
+				continue
+			}
+			leader.IsServLeader = true
+			leader.IsEtcdLeader = true
+		}
+		if leader != nil {
+			log.L().Info("start to watch server master leader",
+				zap.String("leader-name", leader.Name), zap.Strings("addrs", leader.Addrs))
+			s.watchLeader(ctx, leader, rev)
+			log.L().Info("server master leader changed")
+		}
+		if !s.isEtcdLeader() {
+			log.L().Info("skip campaigning leader", zap.String("name", s.name()))
+			time.Sleep(retryInterval)
+			continue
+		}
+		err = s.campaign(ctx, time.Second*5)
+		if err != nil {
+			continue
+		}
+
+		err = s.runLeaderService(s.leaderCtx)
+		if err != nil {
+			if perrors.Cause(err) == context.Canceled ||
+				errors.ErrMasterSessionDone.Equal(err) ||
+				errors.ErrEtcdLeaderChanged.Equal(err) {
+				log.L().Info("leader service exits", zap.Error(err))
+			} else {
+				log.L().Error("run leader service failed", zap.Error(err))
+			}
+		}
 	}
 }
 
 func (s *Server) resign() {
 	s.resignFn()
+}
+
+func (s *Server) campaign(ctx context.Context, timeout time.Duration) error {
+	log.L().Info("start to campaign server master leader", zap.String("name", s.name()))
+	leaderCtx, resignFn, err := s.election.Campaign(ctx, s.member(), time.Second*5)
+	switch err {
+	case nil:
+	case context.Canceled:
+		return ctx.Err()
+	default:
+		log.L().Warn("campaign leader failed", zap.Error(err))
+		return errors.Wrap(errors.ErrMasterCampaignLeader, err)
+	}
+	s.leaderCtx = leaderCtx
+	s.resignFn = resignFn
+	log.L().Info("campaign leader successfully", zap.String("name", s.name()))
+	return nil
 }
 
 func (s *Server) createLeaderClient(ctx context.Context, addrs []string) {
@@ -62,5 +132,51 @@ func (s *Server) closeLeaderClient() {
 			log.L().Warn("close leader client met error", zap.Error(err))
 		}
 		s.leaderClient = nil
+	}
+}
+
+func (s *Server) isEtcdLeader() bool {
+	return s.etcd.Server.Lead() == uint64(s.etcd.Server.ID())
+}
+
+func (s *Server) watchLeader(ctx context.Context, m *Member, rev int64) {
+	m.IsServLeader = true
+	m.IsEtcdLeader = true
+	s.leader.Store(m)
+	s.createLeaderClient(ctx, m.Addrs)
+	defer s.leader.Store(&Member{})
+
+	watcher := clientv3.NewWatcher(s.etcdClient)
+	defer watcher.Close()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		leaderPath := adapter.MasterCampaignKey.Path()
+		rch := watcher.Watch(ctx, leaderPath, clientv3.WithPrefix(), clientv3.WithRev(rev))
+		for wresp := range rch {
+			if wresp.CompactRevision != 0 {
+				log.L().Warn("watch leader met compacted error",
+					zap.Int64("required-revision", rev),
+					zap.Int64("compact-revision", wresp.CompactRevision),
+				)
+				rev = wresp.CompactRevision
+				break
+			}
+			if wresp.Canceled {
+				log.L().Warn("leadership watcher is canceled",
+					zap.Int64("revision", rev), zap.String("leader-name", m.Name),
+					zap.Error(wresp.Err()))
+				return
+			}
+			for _, ev := range wresp.Events {
+				if ev.Type == mvccpb.DELETE {
+					log.L().Info("current leader is resigned", zap.String("leader-name", m.Name))
+					return
+				}
+			}
+		}
 	}
 }

--- a/master/cluster/election_test.go
+++ b/master/cluster/election_test.go
@@ -70,7 +70,7 @@ func TestEtcdElectionCampaign(t *testing.T) {
 			require.NoError(t, err)
 
 			nodeID := fmt.Sprintf("node-%d", i)
-			sessCtx, resignFn, err := election.Campaign(ctx, nodeID)
+			sessCtx, resignFn, err := election.Campaign(ctx, nodeID, time.Second*5)
 			require.NoError(t, err)
 
 			// We have been elected

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -51,6 +51,8 @@ var (
 	// master etcd related errors
 	ErrMasterEtcdCreateSessionFail    = errors.Normalize("failed to create Etcd session", errors.RFCCodeText("DFLOW:ErrMasterEtcdCreateSessionFail"))
 	ErrMasterEtcdElectionCampaignFail = errors.Normalize("failed to campaign for leader", errors.RFCCodeText("DFLOW:ErrMasterEtcdElectionCampaignFail"))
+	ErrMasterNoLeader                 = errors.Normalize("server master has no leader", errors.RFCCodeText("DFLOW:ErrMasterNoLeader"))
+	ErrEtcdLeaderChanged              = errors.Normalize("etcd leader has changed", errors.RFCCodeText("DFLOW:ErrEtcdLeaderChanged"))
 
 	// executor related errors
 	ErrExecutorConfigParseFlagSet = errors.Normalize("parse config flag set failed", errors.RFCCodeText("DFLOW:ErrExecutorConfigParseFlagSet"))


### PR DESCRIPTION
Finish part of https://github.com/hanfei1991/microcosm/issues/6 and https://github.com/hanfei1991/microcosm/issues/42

- Server master only campaigns to be leader when
  - there is no leader
  - and this server is etcd leader
- If etcd leader transfers, the server master leader transfers too. 