### PR TITLE
election: fix panic missing cancel error in context

### DIFF
--- a/master/cluster/election_test.go
+++ b/master/cluster/election_test.go
@@ -120,4 +120,5 @@ func TestLeaderCtxCancelPropagate(t *testing.T) {
 	_, cancel := context.WithCancel(sessCtx)
 	defer cancel()
 	resignFn()
+	require.EqualError(t, sessCtx.Err(), "[DFLOW:ErrMasterSessionDone]master session is done")
 }

--- a/master/cluster/election_test.go
+++ b/master/cluster/election_test.go
@@ -100,3 +100,24 @@ func TestEtcdElectionCampaign(t *testing.T) {
 
 // TODO (zixiong) add tests for failure cases
 // We need a mock Etcd client.
+
+func TestLeaderCtxCancelPropagate(t *testing.T) {
+	newClient, closeFn := setUpTest(t)
+	defer closeFn()
+
+	ctx := context.Background()
+	client := newClient()
+	election, err := NewEtcdElection(ctx, client, nil, EtcdElectionConfig{
+		CreateSessionTimeout: 1 * time.Second,
+		TTL:                  5,
+		Prefix:               "/test-election",
+	})
+	require.NoError(t, err)
+
+	nodeID := "node-cancel-propagate"
+	sessCtx, resignFn, err := election.Campaign(ctx, nodeID, time.Second*5)
+	require.NoError(t, err)
+	_, cancel := context.WithCancel(sessCtx)
+	defer cancel()
+	resignFn()
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -47,6 +47,7 @@ var (
 	ErrMasterCampaignLeader         = errors.Normalize("master campaign to be leader failed", errors.RFCCodeText("DFLOW:ErrMasterCampaignLeader"))
 	ErrMasterSessionDone            = errors.Normalize("master session is done", errors.RFCCodeText("DFLOW:ErrMasterSessionDone"))
 	ErrMasterRPCNotForward          = errors.Normalize("server grpc is not forwarded to leader", errors.RFCCodeText("DFLOW:ErrMasterRPCNotForward"))
+	ErrLeaderCtxCanceled            = errors.Normalize("leader context is canceled", errors.RFCCodeText("DFLOW:ErrLeaderCtxCanceled"))
 
 	// master etcd related errors
 	ErrMasterEtcdCreateSessionFail    = errors.Normalize("failed to create Etcd session", errors.RFCCodeText("DFLOW:ErrMasterEtcdCreateSessionFail"))


### PR DESCRIPTION
When a context is Done, it will notify all children context derived from it, and the `ctx.Err()` must return a nil error, otherwise panic will be raised.

```go
panic: context: internal error: missing cancel error

goroutine 8 [running]:
context.(*cancelCtx).cancel(0xc000100080, 0x0, 0x0, 0x0)
        /home/apple/.gvm/gos/go1.16.4/src/context/context.go:396 +0x2bb
context.propagateCancel.func1(0x4f01e0, 0xc000100040, 0x4efbb0, 0xc000100080)
        /home/apple/.gvm/gos/go1.16.4/src/context/context.go:281 +0x115
created by context.propagateCancel
        /home/apple/.gvm/gos/go1.16.4/src/context/context.go:278 +0x1fb
exit status 2
```

A sample reproduce code

```go
package main

import (
	"context"
	"log"
	"time"
)

type customContext struct {
	context.Context
}

func newCustomContext(parent context.Context) *customContext {
	return &customContext{Context: parent}
}

func (c *customContext) Done() <-chan struct{} {
	doneCh := make(chan struct{})
	go func() {
		select {
		case <-c.Context.Done():
		case <-time.After(time.Millisecond * 100):
		}
		close(doneCh)
	}()
	return doneCh
}

func main() {
	ctx := newCustomContext(context.Background())
	_, cancel := context.WithCancel(ctx)
	defer cancel()
	<-ctx.Done()
	log.Print("runs successfully")
}
```
