### PR TITLE
master: make embed etcd server startup cancelable

### DIFF
--- a/master/server.go
+++ b/master/server.go
@@ -302,7 +302,7 @@ func (s *Server) Run(ctx context.Context) (err error) {
 		return s.startForTest(ctx)
 	}
 
-	err = s.startGrpcSrv()
+	err = s.startGrpcSrv(ctx)
 	if err != nil {
 		return
 	}
@@ -325,7 +325,7 @@ func (s *Server) Run(ctx context.Context) (err error) {
 	return wg.Wait()
 }
 
-func (s *Server) startGrpcSrv() (err error) {
+func (s *Server) startGrpcSrv(ctx context.Context) (err error) {
 	etcdCfg := etcdutils.GenEmbedEtcdConfigWithLogger(s.cfg.LogLevel)
 	// prepare to join an existing etcd cluster.
 	err = etcdutils.PrepareJoinEtcd(s.cfg.Etcd, s.cfg.MasterAddr)
@@ -356,7 +356,7 @@ func (s *Server) startGrpcSrv() (err error) {
 	}
 
 	// generate grpcServer
-	s.etcd, err = startEtcd(etcdCfg, gRPCSvr, httpHandlers, etcdStartTimeout)
+	s.etcd, err = startEtcd(ctx, etcdCfg, gRPCSvr, httpHandlers, etcdStartTimeout)
 	if err != nil {
 		return
 	}

--- a/master/server_test.go
+++ b/master/server_test.go
@@ -1,26 +1,29 @@
 package master
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/phayes/freeport"
 	"github.com/pingcap/tiflow/dm/pkg/log"
 	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	err := log.InitLogger(&log.Config{Level: "warn"})
+	if err != nil {
+		panic(err)
+	}
+}
+
 func TestStartGrpcSrv(t *testing.T) {
 	t.Parallel()
-
-	err := log.InitLogger(&log.Config{
-		File:   "",
-		Level:  "warn",
-		Format: "json",
-	})
-	require.Nil(t, err)
 
 	dir, err := ioutil.TempDir("", "test-start-grpc-srv")
 	require.Nil(t, err)
@@ -43,11 +46,50 @@ initial-cluster = "server-master-1=http://127.0.0.1:%d"`
 	require.Nil(t, err)
 
 	s := &Server{cfg: cfg}
-	err = s.startGrpcSrv()
+	ctx := context.Background()
+	err = s.startGrpcSrv(ctx)
 	require.Nil(t, err)
 
 	testPprof(t, fmt.Sprintf("http://127.0.0.1:%d", ports[0]))
 	s.Stop()
+}
+
+func TestStartGrpcSrvCancelable(t *testing.T) {
+	t.Parallel()
+
+	dir, err := ioutil.TempDir("", "test-start-grpc-srv-cancelable")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+	ports, err := freeport.GetFreePorts(3)
+	require.Nil(t, err)
+	cfgTpl := `
+master-addr = "127.0.0.1:%d"
+advertise-addr = "127.0.0.1:%d"
+[etcd]
+name = "server-master-1"
+data-dir = "%s"
+peer-urls = "http://127.0.0.1:%d"
+initial-cluster = "server-master-1=http://127.0.0.1:%d,server-master-2=http://127.0.0.1:%d"`
+	cfgStr := fmt.Sprintf(cfgTpl, ports[0], ports[0], dir, ports[1], ports[1], ports[2])
+	cfg := NewConfig()
+	err = cfg.configFromString(cfgStr)
+	require.Nil(t, err)
+	err = cfg.adjust()
+	require.Nil(t, err)
+
+	s := &Server{cfg: cfg}
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err = s.startGrpcSrv(ctx)
+	}()
+	// sleep a short time to ensure embed etcd is being started
+	time.Sleep(time.Millisecond * 100)
+	cancel()
+	wg.Wait()
+	require.EqualError(t, err, context.Canceled.Error())
 }
 
 func testPprof(t *testing.T, addr string) {


### PR DESCRIPTION
When start a server master, the startup timeout of embed etcd is 1minute, and the startup procedure can't be cancelled before timeout.
- Pass the context to make embed etcd server startup cancelable.