### PR TITLE
master: use advertise-addr in server master membership

### DIFF
--- a/client/master_client.go
+++ b/client/master_client.go
@@ -119,7 +119,7 @@ func (c *MasterClient) rpcWrap(ctx context.Context, req interface{}, respPointer
 	c.clientsLock.RLock()
 	defer c.clientsLock.RUnlock()
 	var err error
-	for _, cliH := range c.clients {
+	for addr, cliH := range c.clients {
 		params := []reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(req)}
 		results := reflect.ValueOf(cliH.client).MethodByName(methodName).Call(params)
 		// result's inner types should be (*pb.XXResponse, error), which is same as pb.MasterClient.XXRPCMethod
@@ -134,7 +134,7 @@ func (c *MasterClient) rpcWrap(ctx context.Context, req interface{}, respPointer
 		if err != nil {
 			log.L().Error("rpc to server master failed",
 				zap.Any("payload", req), zap.String("method", methodName),
-				zap.Error(err),
+				zap.String("addr", addr), zap.Error(err),
 			)
 		} else {
 			return nil

--- a/cmd/master/example.toml
+++ b/cmd/master/example.toml
@@ -1,4 +1,4 @@
-master-addr = "http://127.0.0.1:10240"
+master-addr = "127.0.0.1:10240"
 [etcd]
 name = "server-master-1"
 data-dir = "/tmp/df/master"

--- a/master/campaign.go
+++ b/master/campaign.go
@@ -62,7 +62,7 @@ func (s *Server) leaderLoop(ctx context.Context) error {
 		}
 		if leader != nil {
 			log.L().Info("start to watch server master leader",
-				zap.String("leader-name", leader.Name), zap.Strings("addrs", leader.Addrs))
+				zap.String("leader-name", leader.Name), zap.String("addr", leader.AdvertiseAddr))
 			s.watchLeader(ctx, leader, rev)
 			log.L().Info("server master leader changed")
 		}
@@ -149,7 +149,7 @@ func (s *Server) watchLeader(ctx context.Context, m *Member, rev int64) {
 	m.IsServLeader = true
 	m.IsEtcdLeader = true
 	s.leader.Store(m)
-	s.createLeaderClient(ctx, m.Addrs)
+	s.createLeaderClient(ctx, []string{m.AdvertiseAddr})
 	defer s.leader.Store(&Member{})
 
 	watcher := clientv3.NewWatcher(s.etcdClient)

--- a/master/config.go
+++ b/master/config.go
@@ -32,10 +32,11 @@ import (
 )
 
 const (
-	defaultSessionTTL        = 5 * time.Second
-	defaultKeepAliveTTL      = "20s"
-	defaultKeepAliveInterval = "500ms"
-	defaultRPCTimeout        = "3s"
+	defaultSessionTTL         = 5 * time.Second
+	defaultKeepAliveTTL       = "20s"
+	defaultKeepAliveInterval  = "500ms"
+	defaultRPCTimeout         = "3s"
+	defaultMemberLoopInterval = 10 * time.Second
 
 	defaultPeerUrls            = "http://127.0.0.1:8291"
 	defaultInitialClusterState = embed.ClusterStateFlagNew
@@ -173,7 +174,7 @@ func (c *Config) adjust() (err error) {
 	c.Etcd.Adjust(defaultPeerUrls, defaultInitialClusterState)
 
 	if c.AdvertiseAddr == "" {
-		c.AdvertiseAddr = c.Etcd.PeerUrls
+		c.AdvertiseAddr = c.MasterAddr
 	}
 
 	if c.KeepAliveIntervalStr == "" {

--- a/master/member.go
+++ b/master/member.go
@@ -4,17 +4,20 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/hanfei1991/microcosm/pkg/adapter"
+	"github.com/hanfei1991/microcosm/pkg/errors"
 	"github.com/pingcap/tiflow/dm/pkg/log"
+	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
 )
 
 // Member stores server member information
 // TODO: make it a protobuf field and can be shared by gRPC API
 type Member struct {
-	IsServLeader bool     `json:"is-serv-leader"`
-	IsEtcdLeader bool     `json:"is-etcd-leader"`
-	Name         string   `json:"name"`
-	Addrs        []string `json:"addrs"`
+	IsServLeader  bool   `json:"is-serv-leader"`
+	IsEtcdLeader  bool   `json:"is-etcd-leader"`
+	Name          string `json:"name"`
+	AdvertiseAddr string `json:"advertise-addr"`
 }
 
 // String implements json marshal
@@ -28,24 +31,71 @@ func (m *Member) Unmarshal(data []byte) error {
 	return json.Unmarshal(data, m)
 }
 
-func (s *Server) updateServerMasterMembers(ctx context.Context) error {
-	resp, err := s.etcdClient.MemberList(ctx)
+// Membership defines the interface to query member information in metastore
+type Membership interface {
+	GetConfigs(ctx context.Context) (map[string]*Config, error)
+	GetMembers(ctx context.Context, leader *Member, etcdLeaderID uint64) ([]*Member, error)
+}
+
+type EtcdMembership struct {
+	etcdCli *clientv3.Client
+}
+
+func (em *EtcdMembership) GetConfigs(ctx context.Context) (map[string]*Config, error) {
+	resp, err := em.etcdCli.Get(ctx, adapter.MasterInfoKey.Path(), clientv3.WithPrefix())
 	if err != nil {
-		return err
+		return nil, errors.Wrap(errors.ErrEtcdAPIError, err)
+	}
+	cfgs := make(map[string]*Config, resp.Count)
+	for _, kv := range resp.Kvs {
+		cfg := &Config{}
+		err := json.Unmarshal(kv.Value, cfg)
+		if err != nil {
+			return nil, errors.Wrap(errors.ErrDecodeEtcdKeyFail, err)
+		}
+		cfgs[cfg.Etcd.Name] = cfg
+	}
+	return cfgs, nil
+}
+
+func (em *EtcdMembership) GetMembers(ctx context.Context, leader *Member, etcdLeaderID uint64) ([]*Member, error) {
+	servers, err := em.GetConfigs(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	members := make([]*Member, 0, len(resp.Members))
-	leader, exists := s.checkLeader()
-	etcdLeaderID := s.etcd.Server.Lead()
-	for _, m := range resp.Members {
-		isServLeader := exists && m.Name == leader.Name
+	etcdMembers, err := em.etcdCli.MemberList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	members := make([]*Member, 0, len(etcdMembers.Members))
+	for _, m := range etcdMembers.Members {
+		server, ok := servers[m.Name]
+		if !ok {
+			continue
+		}
+		isServLeader := leader != nil && m.Name == leader.Name
 		isEtcdLeader := m.ID == etcdLeaderID
 		members = append(members, &Member{
-			Name:         m.Name,
-			Addrs:        m.ClientURLs,
-			IsEtcdLeader: isEtcdLeader,
-			IsServLeader: isServLeader,
+			Name:          m.Name,
+			AdvertiseAddr: server.AdvertiseAddr,
+			IsEtcdLeader:  isEtcdLeader,
+			IsServLeader:  isServLeader,
 		})
+	}
+	return members, nil
+}
+
+func (s *Server) updateServerMasterMembers(ctx context.Context) error {
+	leader, exists := s.checkLeader()
+	if !exists {
+		leader = nil
+	}
+	etcdLeaderID := s.etcd.Server.Lead()
+	members, err := s.membership.GetMembers(ctx, leader, etcdLeaderID)
+	if err != nil {
+		return err
 	}
 	s.members.Lock()
 	defer s.members.Unlock()

--- a/master/member_test.go
+++ b/master/member_test.go
@@ -1,0 +1,87 @@
+package master
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hanfei1991/microcosm/pkg/adapter"
+	"github.com/hanfei1991/microcosm/pkg/etcdutils"
+	"github.com/phayes/freeport"
+	"github.com/pingcap/tiflow/dm/pkg/log"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/embed"
+)
+
+func init() {
+	// initialized the logger to make genEmbedEtcdConfig working.
+	err := log.InitLogger(&log.Config{})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func allocTempURL(t *testing.T) string {
+	port, err := freeport.GetFreePort()
+	require.Nil(t, err)
+	return fmt.Sprintf("127.0.0.1:%d", port)
+}
+
+func TestMembershipIface(t *testing.T) {
+	t.Parallel()
+
+	dir, err := ioutil.TempDir("", "test1")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	masterAddr := allocTempURL(t)
+	advertiseAddr := masterAddr
+	cfgCluster := &etcdutils.ConfigParams{}
+	cfgCluster.Name = "dataflow-master-1"
+	cfgCluster.DataDir = dir
+	cfgCluster.PeerUrls = "http://" + allocTempURL(t)
+	cfgCluster.Adjust("", embed.ClusterStateFlagNew)
+
+	cfgClusterEtcd := etcdutils.GenEmbedEtcdConfigWithLogger("info")
+	cfgClusterEtcd, err = etcdutils.GenEmbedEtcdConfig(cfgClusterEtcd, masterAddr, advertiseAddr, cfgCluster)
+	require.Nil(t, err)
+
+	etcd, err := etcdutils.StartEtcd(cfgClusterEtcd, nil, nil, time.Minute)
+	require.Nil(t, err)
+	defer etcd.Close()
+
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{advertiseAddr},
+		DialTimeout: 3 * time.Second,
+	})
+	require.Nil(t, err)
+
+	// prepare master info config
+	ctx := context.Background()
+	cfg := NewConfig()
+	cfg.Etcd.Name = cfgCluster.Name
+	cfg.AdvertiseAddr = advertiseAddr
+	cfgBytes, err := json.Marshal(cfg)
+	require.Nil(t, err)
+	_, err = client.Put(ctx, adapter.MasterInfoKey.Encode(cfgCluster.Name), string(cfgBytes))
+	require.Nil(t, err)
+
+	// test Membership.GetConfigs
+	membership := &EtcdMembership{etcdCli: client}
+	cfgs, err := membership.GetConfigs(ctx)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(cfgs))
+	require.Contains(t, cfgs, cfgCluster.Name)
+
+	// test Membership.GetMembers
+	etcdLeaderID := etcd.Server.Lead()
+	leader := &Member{Name: cfgCluster.Name}
+	members, err := membership.GetMembers(ctx, leader, etcdLeaderID)
+	require.Nil(t, err)
+	require.Len(t, members, 1)
+}


### PR DESCRIPTION
- Add a membership interface in server master
- Use `AdvertiseAddr` in member struct, which is more accurate for server discovery.