### PR TITLE
master: fix nil leader used in isLeaderAndNeedForward

### DIFF
--- a/master/server.go
+++ b/master/server.go
@@ -473,7 +473,7 @@ func (s *Server) isLeaderAndNeedForward(ctx context.Context) (isLeader, needForw
 		ticker := time.NewTicker(300 * time.Millisecond)
 		defer ticker.Stop()
 
-		for exist {
+		for !exist {
 			if retry == 0 {
 				log.L().Error("leader is not found, please retry later")
 				return false, false


### PR DESCRIPTION
Fix the following panic when starting master server

```golang
[2022/01/10 18:07:30.378 +08:00] [INFO] [server.go:503] [payload="address:\"127.0.0.1:10241\" capability:100 "] [request=RegisterExecutor]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xf2f5ed]

goroutine 187 [running]:
github.com/hanfei1991/microcosm/master.(*Server).isLeaderAndNeedForward(0xc00010e820, 0x133dd18, 0xc0003b46c0, 0xc000120000)
        /home/apple/work/code/pingcap/microcosm/master/server.go:490 +0x30d
github.com/hanfei1991/microcosm/master.(*Server).rpcForwardIfNeeded(0xc00010e820, 0x133dd18, 0xc0003b46c0, 0x112d140, 0xc0003b46f0, 0xf8fa80, 0xc00011a620, 0xc0004d5680, 0xc00039afc0)
        /home/apple/work/code/pingcap/microcosm/master/server.go:505 +0x2e6
github.com/hanfei1991/microcosm/master.(*Server).RegisterExecutor(0xc00010e820, 0x133dd18, 0xc0003b46c0, 0xc0003b46f0, 0xc00010e820, 0x1344890, 0xc00039afc0)
        /home/apple/work/code/pingcap/microcosm/master/server.go:180 +0xbf
github.com/hanfei1991/microcosm/pb._Master_RegisterExecutor_Handler.func1(0x133dd18, 0xc0003b46c0, 0x112d140, 0xc0003b46f0, 0x1b, 0xc000406d70, 0x2, 0xc0004ac810)
        /home/apple/work/code/pingcap/microcosm/pb/master.pb.go:1221 +0x89
github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1(0x133dd18, 0xc0003b46c0, 0x112d140, 0xc0003b46f0, 0xc00037a3a0, 0xc00036aa38, 0xc0001751e0, 0x0, 0x0, 0x0)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 +0xb0
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1(0x133dd18, 0xc0003b46c0, 0x112d140, 0xc0003b46f0, 0x19f1ec0, 0xc00039af00, 0xc00004b3f0, 0xc0000486aa)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 +0x63
go.etcd.io/etcd/etcdserver/api/v3rpc.newUnaryInterceptor.func1(0x133dd18, 0xc0003b46c0, 0x112d140, 0xc0003b46f0, 0xc00037a3a0, 0xc00037a3c0, 0x499546, 0x61dc0562, 0x168cc578, 0x14e52fd8b547e)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/go.etcd.io/etcd@v0.5.0-alpha.5.0.20210512015243-d19fbe541bf9/etcdserver/api/v3rpc/interceptor.go:70 +0x15c
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1(0x133dd18, 0xc0003b46c0, 0x112d140, 0xc0003b46f0, 0x9a3f29, 0xc0003b46f0, 0x203000, 0x13)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 +0x63
go.etcd.io/etcd/etcdserver/api/v3rpc.newLogUnaryInterceptor.func1(0x133dd18, 0xc0003b46c0, 0x112d140, 0xc0003b46f0, 0xc00037a3a0, 0xc00037a3e0, 0x0, 0x0, 0x0, 0x0)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/go.etcd.io/etcd@v0.5.0-alpha.5.0.20210512015243-d19fbe541bf9/etcdserver/api/v3rpc/interceptor.go:77 +0xd9
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1.1.1(0x133dd18, 0xc0003b46c0, 0x112d140, 0xc0003b46f0, 0xc00040e000, 0x0, 0xc0004acb30, 0x40fef8)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:25 +0x63
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryServer.func1(0x133dd18, 0xc0003b46c0, 0x112d140, 0xc0003b46f0, 0xc00037a3a0, 0xc00036aa38, 0xc0004acba0, 0x4a4fa6, 0x10e0960, 0xc0003b46c0)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.1.0/chain.go:34 +0xd7
github.com/hanfei1991/microcosm/pb._Master_RegisterExecutor_Handler(0x1160460, 0xc00010e820, 0x133dd18, 0xc0003b46c0, 0xc00039aea0, 0xc00036ff20, 0x133dd18, 0xc0003b46c0, 0xc0000486a8, 0x13)
        /home/apple/work/code/pingcap/microcosm/pb/master.pb.go:1223 +0x150
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000133d40, 0x134a238, 0xc000432780, 0xc0003fc000, 0xc00039ddd0, 0x19adee0, 0x0, 0x0, 0x0)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/google.golang.org/grpc@v1.29.1/server.go:1082 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc000133d40, 0x134a238, 0xc000432780, 0xc0003fc000, 0x0)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/google.golang.org/grpc@v1.29.1/server.go:1405 +0xccf
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc000350640, 0xc000133d40, 0x134a238, 0xc000432780, 0xc0003fc000)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/google.golang.org/grpc@v1.29.1/server.go:746 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/google.golang.org/grpc@v1.29.1/server.go:744 +0xa5
```