### PR TITLE
test: fix unstable pause job test

### DIFF
--- a/test/job_test.go
+++ b/test/job_test.go
@@ -112,10 +112,19 @@ func (t *testJobSuite) TestPause(c *C) {
 	cnt := int32(0)
 	for {
 		data := executorCtx.RecvRecord(ctx)
-		if data == nil {
-			break
+		if data != nil {
+			cnt++
+			continue
 		}
-		cnt++
+		// try to consume all data in data channel
+		for {
+			data = executorCtx.TryRecvRecord()
+			if data == nil {
+				break
+			}
+			cnt++
+		}
+		break
 	}
 	c.Assert(cnt, Less, testJobConfig.TableNum*testJobConfig.RecordCnt)
 	log.L().Logger.Info("has read", zap.Int32("cnt", cnt))

--- a/test/job_test.go
+++ b/test/job_test.go
@@ -107,7 +107,9 @@ func (t *testJobSuite) TestPause(c *C) {
 	susResp, err := client.PauseJob(context.Background(), susReq)
 	c.Assert(err, IsNil)
 	c.Assert(susResp.Err, IsNil)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	// TODO: sleep 2s here to ensure pauseJob is called in executor. Find a better
+	// way to check job is paused instead of waiting some time.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()
 	cnt := int32(0)
 	for {
@@ -128,9 +130,9 @@ func (t *testJobSuite) TestPause(c *C) {
 	}
 	c.Assert(cnt, Less, testJobConfig.TableNum*testJobConfig.RecordCnt)
 	log.L().Logger.Info("has read", zap.Int32("cnt", cnt))
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	c.Assert(executorCtx.TryRecvRecord(), IsNil)
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	c.Assert(executorCtx.TryRecvRecord(), IsNil)
 	cluster.StopCluster()
 }


### PR DESCRIPTION
Fix the following unstable test, try to consume data when executor context is canceled.

```golang
[2022/01/13 03:54:09.128 +00:00] [INFO] [executor_manager.go:77] ["handle heart beat"] [req="executor_id:\"0d0a3a3c-1fb3-46c2-8b3c-b03e49566cd7\" status:1 timestamp:1642046049 ttl:20000001000 "]
[2022/01/13 03:54:09.128 +00:00] [INFO] [server.go:365] ["heartbeat success"] [leader=] [members="[]"]
[2022/01/13 03:54:09.359 +00:00] [INFO] [server.go:508] [payload="executor_id:\"0d0a3a3c-1fb3-46c2-8b3c-b03e49566cd7\" status:1 timestamp:1642046049 ttl:20000001000 "] [request=Heartbeat]
[2022/01/13 03:54:09.360 +00:00] [INFO] [executor_manager.go:77] ["handle heart beat"] [req="executor_id:\"0d0a3a3c-1fb3-46c2-8b3c-b03e49566cd7\" status:1 timestamp:1642046049 ttl:20000001000 "]
[2022/01/13 03:54:09.360 +00:00] [INFO] [server.go:365] ["heartbeat success"] [leader=] [members="[]"]

----------------------------------------------------------------------
FAIL: job_test.go:82: testJobSuite.TestPause

job_test.go:123:
    c.Assert(executorCtx.TryRecvRecord(), IsNil)
... value *runtime.Record = &runtime.Record{FlowID:"", End:time.Time{wall:0xc070067833bd136a, ext:15227299803, loc:(*time.Location)(0x2af2fc0)}, Payload:(*pb.Record)(0xc0005318c0), Tid:4}


OOPS: 2 passed, 1 FAILED
--- FAIL: TestT (23.98s)
FAIL
[2022/01/13 03:54:17.680 +00:00] [INFO] [impl.go:259] ["begin to cancel tasks"] [exec=3ca96f57-5114-4e65-8abd-587a06e4469d] [task="[{\"flow_id\":\"jobtest\",\"id\":4294967310,\"outputs\":[4294967311],\"inputs\":null,\"type\":0,\"op\":\"eyJmbG93LWlkIjoiam9idGVzdCIsImFkZHJlc3MiOiIxMjcuMC4wLjE6MzczOTkifQ==\",\"cost\":1,\"location\":\"\",\"exec\":\"3ca96f57-5114-4e65-8abd-587a06e4469d\",\"Status\":0},{\"flow_id\":\"jobtest\",\"id\":4294967313,\"outputs\":[4294967314],\"inputs\":null,\"type\":0,\"op\":\"eyJmbG93LWlkIjoiam9idGVzdCIsImFkZHJlc3MiOiIxMjcuMC4wLjE6NDA4NjEifQ==\",\"cost\":1,\"location\":\"\",\"exec\":\"3ca96f57-5114-4e65-8abd-587a06e4469d\",\"Status\":0},{\"flow_id\":\"jobtest\",\"id\":4294967316,\"outputs\":[4294967317],\"inputs\":null,\"type\":0,\"op\":\"eyJmbG93LWlkIjoiam9idGVzdCIsImFkZHJlc3MiOiIxMjcuMC4wLjE6NDE0NDcifQ==\",\"cost\":1,\"location\":\"\",\"exec\":\"3ca96f57-5114-4e65-8abd-587a06e4469d\",\"Status\":0},{\"flow_id\":\"jobtest\",\"id\":4294967311,\"outputs\":[4294967312],\"inputs\":[4294967310],\"type\":1,\"op\":\"eyJpZCI6MH0=\",\"cost\":1,\"location\":\"\",\"exec\":\"3ca96f57-5114-4e65-8abd-587a06e4469d\",\"Status\":0},{\"flow_id\":\"jobtest\",\"id\":4294967314,\"outputs\":[4294967315],\"inputs\":[4294967313],\"type\":1,\"op\":\"eyJpZCI6MH0=\",\"cost\":1,\"location\":\"\",\"exec\":\"3ca96f57-5114-4e65-8abd-587a06e4469d\",\"Status\":0},{\"flow_id\":\"jobtest\",\"id\":4294967317,\"outputs\":[4294967318],\"inputs\":[4294967316],\"type\":1,\"op\":\"eyJpZCI6MH0=\",\"cost\":1,\"location\":\"\",\"exec\":\"3ca96f57-5114-4e65-8abd-587a06e4469d\",\"Status\":0},{\"flow_id\":\"jobtest\",\"id\":4294967312,\"outputs\":null,\"inputs\":[4294967311],\"type\":2,\"op\":\"eyJpZCI6MCwiZmlsZSI6Ii90bXAvZGF0YWZsb3cvam9idGVzdC90YWJsZV8wIn0=\",\"cost\":1,\"location\":\"\",\"exec\":\"3ca96f57-5114-4e65-8abd-587a06e4469d\",\"Status\":0},{\"flow_id\":\"jobtest\",\"id\":4294967315,\"outputs\":null,\"inputs\":[4294967314],\"type\":2,\"op\":\"eyJpZCI6MCwiZmlsZSI6Ii90bXAvZGF0YWZsb3cvam9idGVzdC90YWJsZV8xIn0=\",\"cost\":1,\"location\":\"\",\"exec\":\"3ca96f57-5114-4e65-8abd-587a06e4469d\",\"Status\":0},{\"flow_id\":\"jobtest\",\"id\":4294967318,\"outputs\":null,\"inputs\":[4294967317],\"type\":2,\"op\":\"eyJpZCI6MCwiZmlsZSI6Ii90bXAvZGF0YWZsb3cvam9idGVzdC90YWJsZV8yIn0=\",\"cost\":1,\"location\":\"\",\"exec\":\"3ca96f57-5114-4e65-8abd-587a06e4469d\",\"Status\":0}]"]
[2022/01/13 03:54:17.704 +00:00] [INFO] [server.go:85] ["cancel tasks"] [req="task_id_list:4294967310 task_id_list:4294967313 task_id_list:4294967316 task_id_list:4294967311 task_id_list:4294967314 task_id_list:4294967317 task_id_list:4294967312 task_id_list:4294967315 task_id_list:4294967318 "]
coverage: 93.8% of statements
FAIL	github.com/hanfei1991/microcosm/test	24.160s
```