### PR TITLE
etcd: add AutoSyncInterval config to etcd client

### DIFF
--- a/executor/runtime/jobmaster/build.go
+++ b/executor/runtime/jobmaster/build.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hanfei1991/microcosm/jobmaster/system"
 	"github.com/hanfei1991/microcosm/model"
 	"github.com/hanfei1991/microcosm/pb"
+	"github.com/hanfei1991/microcosm/pkg/config"
 	"github.com/hanfei1991/microcosm/pkg/errors"
 	"github.com/hanfei1991/microcosm/pkg/metadata"
 	"github.com/hanfei1991/microcosm/test"
@@ -44,10 +45,11 @@ func getEtcdMetaKV(ctx context.Context, clients *client.Manager) (metadata.MetaK
 	logConfig := logutil.DefaultZapLoggerConfig
 	logConfig.Level = zap.NewAtomicLevelAt(zapcore.ErrorLevel)
 	etcdCli, err := clientv3.New(clientv3.Config{
-		Endpoints:   strings.Split(resp.GetAddress(), ","),
-		Context:     ctx,
-		LogConfig:   &logConfig,
-		DialTimeout: 5 * time.Second,
+		Endpoints:        strings.Split(resp.GetAddress(), ","),
+		Context:          ctx,
+		LogConfig:        &logConfig,
+		DialTimeout:      config.ServerMasterEtcdDialTimeout,
+		AutoSyncInterval: config.ServerMasterEtcdSyncInterval,
 		DialOptions: []grpc.DialOption{
 			grpc.WithInsecure(),
 			grpc.WithBlock(),

--- a/executor/server.go
+++ b/executor/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hanfei1991/microcosm/executor/runtime"
 	"github.com/hanfei1991/microcosm/model"
 	"github.com/hanfei1991/microcosm/pb"
+	"github.com/hanfei1991/microcosm/pkg/config"
 	"github.com/hanfei1991/microcosm/pkg/errors"
 	"github.com/hanfei1991/microcosm/pkg/metadata"
 	"github.com/hanfei1991/microcosm/test"
@@ -241,10 +242,11 @@ func (s *Server) keepalive(ctx context.Context) error {
 	logConfig := logutil.DefaultZapLoggerConfig
 	logConfig.Level = zap.NewAtomicLevelAt(zapcore.ErrorLevel)
 	etcdCli, err := clientv3.New(clientv3.Config{
-		Endpoints:   strings.Split(resp.GetAddress(), ","),
-		Context:     ctx,
-		LogConfig:   &logConfig,
-		DialTimeout: 5 * time.Second,
+		Endpoints:        strings.Split(resp.GetAddress(), ","),
+		Context:          ctx,
+		LogConfig:        &logConfig,
+		DialTimeout:      config.ServerMasterEtcdDialTimeout,
+		AutoSyncInterval: config.ServerMasterEtcdSyncInterval,
 		DialOptions: []grpc.DialOption{
 			grpc.WithInsecure(),
 			grpc.WithBlock(),

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -1,0 +1,11 @@
+package config
+
+import (
+	"time"
+)
+
+// Define some constants
+const (
+	ServerMasterEtcdDialTimeout  = 5 * time.Second
+	ServerMasterEtcdSyncInterval = 3 * time.Second
+)

--- a/servermaster/campaign.go
+++ b/servermaster/campaign.go
@@ -71,7 +71,7 @@ func (s *Server) leaderLoop(ctx context.Context) error {
 			time.Sleep(retryInterval)
 			continue
 		}
-		err = s.campaign(ctx, time.Second*5)
+		err = s.campaign(ctx, defaultCampaignTimeout)
 		if err != nil {
 			continue
 		}

--- a/servermaster/config.go
+++ b/servermaster/config.go
@@ -37,6 +37,7 @@ const (
 	defaultKeepAliveInterval  = "500ms"
 	defaultRPCTimeout         = "3s"
 	defaultMemberLoopInterval = 10 * time.Second
+	defaultCampaignTimeout    = 5 * time.Second
 
 	defaultPeerUrls            = "http://127.0.0.1:8291"
 	defaultInitialClusterState = embed.ClusterStateFlagNew


### PR DESCRIPTION
This pr is part of task-2 in #91

- Add `AutoSyncInterval` to etcd config, etcd client will start a goroutine to sync etcd endpoints. See more in https://pkg.go.dev/go.etcd.io/etcd/clientv3#Config
- Extract some constants.