### PR TITLE
executor/worker: new simple runtime

### DIFF
--- a/executor/worker/runtime.go
+++ b/executor/worker/runtime.go
@@ -1,0 +1,124 @@
+package worker
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/edwingeng/deque"
+	"github.com/hanfei1991/microcosm/lib"
+	"github.com/hanfei1991/microcosm/model"
+)
+
+type Scheduler struct {
+	sync.Mutex
+
+	ctx              context.Context
+	queue            deque.Deque
+	onWorkerFinished func(lib.Worker, error)
+}
+
+const emptyRestDuration time.Duration = 50 * time.Millisecond
+
+func (s *Scheduler) AddWorker(worker lib.Worker) {
+	s.Lock()
+	s.queue.PushBack(worker)
+	s.Unlock()
+}
+
+func (s *Scheduler) Run(conn int) {
+	for i := 0; i < conn; i++ {
+		go s.runImpl()
+	}
+}
+
+func (s *Scheduler) runImpl() {
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		default:
+		}
+		s.Lock()
+		if s.queue.Empty() {
+			s.Unlock()
+			time.Sleep(emptyRestDuration)
+			continue
+		}
+		worker := s.queue.PopFront().(lib.Worker)
+		s.Unlock()
+		if err := worker.Poll(s.ctx); err != nil {
+			s.onWorkerFinished(worker, err)
+			continue
+		}
+		// TODO: calculate workload
+
+		s.Lock()
+		s.queue.PushBack(worker)
+		s.Unlock()
+	}
+}
+
+func NewRuntime(ctx context.Context) *Runtime {
+	rt := &Runtime{
+		ctx:           ctx,
+		closingWorker: make(chan lib.Worker, 1024),
+		initingWorker: make(chan lib.Worker, 1024),
+		scheduler:     Scheduler{ctx: ctx, queue: deque.NewDeque()},
+	}
+	rt.scheduler.onWorkerFinished = rt.onWorkerFinish
+	return rt
+}
+
+type Runtime struct {
+	workerList sync.Map // map[lib.WorkerID]lib.Worker
+	// We should abstract a schedule interface to implement different
+	// schedule algorithm. For now, we assume every worker consume similar
+	// poll time, so we expect go scheduler can produce a fair result.
+	scheduler     Scheduler
+	closingWorker chan lib.Worker
+	initingWorker chan lib.Worker
+	ctx           context.Context
+}
+
+func (r *Runtime) onWorkerFinish(worker lib.Worker, err error) {
+	r.closingWorker <- worker
+}
+
+func (r *Runtime) closeWorker() {
+	for worker := range r.closingWorker {
+		worker.Close()
+		r.workerList.Delete(worker.ID())
+	}
+}
+
+func (r *Runtime) initWorker() {
+	for worker := range r.initingWorker {
+		if err := worker.Init(r.ctx); err != nil {
+			r.onWorkerFinish(worker, err)
+		} else {
+			r.scheduler.AddWorker(worker)
+		}
+	}
+}
+
+func (r *Runtime) Start(conn int) {
+	go r.closeWorker()
+	go r.initWorker()
+	r.scheduler.Run(conn)
+}
+
+func (r *Runtime) AddWorker(worker lib.Worker) {
+	r.workerList.Store(worker.ID(), worker)
+	r.initingWorker <- worker
+}
+
+func (r *Runtime) Workload() model.RescUnit {
+	ret := model.RescUnit(0)
+	r.workerList.Range(func(_, value interface{}) bool {
+		worker := value.(lib.Worker)
+		ret += worker.Workload()
+		return true
+	})
+	return ret
+}

--- a/executor/worker/runtime_test.go
+++ b/executor/worker/runtime_test.go
@@ -1,0 +1,59 @@
+package worker_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/hanfei1991/microcosm/executor/worker"
+	"github.com/hanfei1991/microcosm/lib"
+	"github.com/hanfei1991/microcosm/lib/fake"
+	"github.com/hanfei1991/microcosm/model"
+	dcontext "github.com/hanfei1991/microcosm/pkg/context"
+)
+
+func TestBasicFunc(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	rt := worker.NewRuntime(ctx)
+	rt.Start(10)
+	workerNum := 1000
+	for i := 0; i < workerNum; i++ {
+		workerImpl := fake.NewDummyWorkerImpl(dcontext.Context{})
+		worker := &dummyWorker{
+			id:   lib.WorkerID("executor" + strconv.Itoa(i)),
+			impl: workerImpl,
+		}
+		rt.AddWorker(worker)
+	}
+	time.Sleep(time.Second)
+	if rtwl := rt.Workload(); int(rtwl) != workerNum {
+		t.Error("not equal", rtwl, workerNum)
+	}
+	cancel()
+}
+
+type dummyWorker struct {
+	id   lib.WorkerID
+	impl lib.WorkerImpl
+}
+
+func (d *dummyWorker) Init(ctx context.Context) error {
+	return d.impl.InitImpl(ctx)
+}
+
+func (d *dummyWorker) Poll(ctx context.Context) error {
+	return d.impl.Tick(ctx)
+}
+
+func (d *dummyWorker) ID() lib.WorkerID {
+	return d.id
+}
+
+func (d *dummyWorker) Workload() model.RescUnit {
+	return model.RescUnit(1)
+}
+
+func (d *dummyWorker) Close() {
+	d.impl.CloseImpl()
+}

--- a/lib/fake/fake_worker.go
+++ b/lib/fake/fake_worker.go
@@ -1,0 +1,61 @@
+package fake
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hanfei1991/microcosm/lib"
+	"github.com/hanfei1991/microcosm/model"
+	dcontext "github.com/hanfei1991/microcosm/pkg/context"
+)
+
+var _ lib.WorkerImpl = &dummyWorkerImpl{}
+
+type dummyWorkerImpl struct {
+	init   bool
+	closed bool
+	tick   int64
+}
+
+func (d *dummyWorkerImpl) InitImpl(ctx context.Context) error {
+	if !d.init {
+		d.init = true
+		return nil
+	}
+	return errors.New("repeated init")
+}
+
+func (d *dummyWorkerImpl) Tick(ctx context.Context) error {
+	if !d.init {
+		return errors.New("not yet init")
+	}
+
+	if d.closed {
+		return nil
+	}
+	d.tick++
+	return nil
+}
+
+func (d *dummyWorkerImpl) Status() (lib.WorkerStatus, error) {
+	if d.init {
+		return lib.WorkerStatus{Code: lib.WorkerStatusNormal, Ext: d.tick}, nil
+	}
+	return lib.WorkerStatus{Code: lib.WorkerStatusCreated}, nil
+}
+
+func (d *dummyWorkerImpl) Workload() (model.RescUnit, error) {
+	return model.RescUnit(10), nil
+}
+
+func (d *dummyWorkerImpl) OnMasterFailover(_ lib.MasterFailoverReason) error {
+	return nil
+}
+
+func (d *dummyWorkerImpl) CloseImpl() {
+	d.closed = true
+}
+
+func NewDummyWorkerImpl(ctx dcontext.Context) lib.WorkerImpl {
+	return &dummyWorkerImpl{}
+}


### PR DESCRIPTION
This PR implements a simple runtime for worker and implements:

- **Start(conn int)** means starting this runtime, with conn goroutines.
- **AddWorker(lib.Worker)** adds a worker to this runtime
- **Workerload() RescUsage** calculate the sum of running workloads.

I abstract the scheduler to implement more sophisticated algo in the future.
The next PR will connect them with outside world.

ref: #93