### PR TITLE
registry: support passing WorkerConfig

### DIFF
--- a/executor/server.go
+++ b/executor/server.go
@@ -155,7 +155,11 @@ func (s *Server) DispatchTask(ctx context.Context, req *pb.DispatchTaskRequest) 
 	}
 
 	newWorker, err := registry.GlobalWorkerRegistry().CreateWorker(
-		dctx, lib.WorkerType(req.TaskTypeId), lib.WorkerID(workerID), lib.MasterID(req.MasterId))
+		dctx,
+		lib.WorkerType(req.GetTaskTypeId()),
+		lib.WorkerID(workerID),
+		lib.MasterID(req.GetMasterId()),
+		req.GetTaskConfig())
 	if err != nil {
 		// TODO better error handling
 		return nil, err

--- a/lib/fake/fake_worker.go
+++ b/lib/fake/fake_worker.go
@@ -62,7 +62,7 @@ func (d *dummyWorker) CloseImpl() {
 	atomic.StoreInt32(&d.closed, 1)
 }
 
-func NewDummyWorker(ctx *dcontext.Context, id lib.WorkerID, masterID lib.MasterID) lib.Worker {
+func NewDummyWorker(ctx *dcontext.Context, id lib.WorkerID, masterID lib.MasterID, _ lib.WorkerConfig) lib.Worker {
 	ret := &dummyWorker{}
 	dependencies := ctx.Dependencies
 	ret.BaseWorker = lib.NewBaseWorker(

--- a/lib/registry/factory.go
+++ b/lib/registry/factory.go
@@ -1,8 +1,12 @@
 package registry
 
 import (
+	"encoding/json"
+	"reflect"
+
 	"github.com/hanfei1991/microcosm/lib"
 	dcontext "github.com/hanfei1991/microcosm/pkg/context"
+	"github.com/pingcap/errors"
 )
 
 // WorkerFactory is an interface that should be implemented by the author of WorkerImpl's.
@@ -12,11 +16,39 @@ type WorkerFactory interface {
 		ctx *dcontext.Context, // We require a `dcontext` here to provide dependencies.
 		workerID lib.WorkerID, // the globally unique workerID for this worker to be created.
 		masterID lib.MasterID, // the masterID that this worker will report to.
+		config WorkerConfig, // the config used to initialize the worker.
 	) (lib.Worker, error)
+
+	DeserializeConfig(configBytes []byte) (WorkerConfig, error)
 }
 
-type ConstructorFuncFactory func(ctx *dcontext.Context, id lib.WorkerID, masterID lib.MasterID) lib.Worker
+type WorkerConstructor func(ctx *dcontext.Context, id lib.WorkerID, masterID lib.MasterID, config WorkerConfig) lib.Worker
 
-func (c ConstructorFuncFactory) NewWorker(ctx *dcontext.Context, workerID lib.WorkerID, masterID lib.MasterID) (lib.Worker, error) {
-	return c(ctx, workerID, masterID), nil
+type SimpleWorkerFactory struct {
+	constructor WorkerConstructor
+	tpi         interface{}
+}
+
+func NewSimpleWorkerFactory(constructor WorkerConstructor, configType interface{}) *SimpleWorkerFactory {
+	return &SimpleWorkerFactory{
+		constructor: constructor,
+		tpi:         configType,
+	}
+}
+
+func (f *SimpleWorkerFactory) NewWorker(
+	ctx *dcontext.Context,
+	workerID lib.WorkerID,
+	masterID lib.MasterID,
+	config WorkerConfig,
+) (lib.Worker, error) {
+	return f.constructor(ctx, workerID, masterID, config), nil
+}
+
+func (f *SimpleWorkerFactory) DeserializeConfig(configBytes []byte) (WorkerConfig, error) {
+	config := reflect.New(reflect.TypeOf(f.tpi).Elem()).Interface()
+	if err := json.Unmarshal(configBytes, config); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return config, nil
 }

--- a/lib/registry/factory.go
+++ b/lib/registry/factory.go
@@ -26,13 +26,13 @@ type WorkerConstructor func(ctx *dcontext.Context, id lib.WorkerID, masterID lib
 
 type SimpleWorkerFactory struct {
 	constructor WorkerConstructor
-	tpi         interface{}
+	configTpi   interface{}
 }
 
 func NewSimpleWorkerFactory(constructor WorkerConstructor, configType interface{}) *SimpleWorkerFactory {
 	return &SimpleWorkerFactory{
 		constructor: constructor,
-		tpi:         configType,
+		configTpi:   configType,
 	}
 }
 
@@ -46,7 +46,7 @@ func (f *SimpleWorkerFactory) NewWorker(
 }
 
 func (f *SimpleWorkerFactory) DeserializeConfig(configBytes []byte) (WorkerConfig, error) {
-	config := reflect.New(reflect.TypeOf(f.tpi).Elem()).Interface()
+	config := reflect.New(reflect.TypeOf(f.configTpi).Elem()).Interface()
 	if err := json.Unmarshal(configBytes, config); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/lib/registry/factory_test.go
+++ b/lib/registry/factory_test.go
@@ -1,0 +1,24 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/hanfei1991/microcosm/lib"
+	"github.com/hanfei1991/microcosm/lib/fake"
+	dcontext "github.com/hanfei1991/microcosm/pkg/context"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSimpleWorkerFactory(t *testing.T) {
+	dummyConstructor := func(ctx *dcontext.Context, id lib.WorkerID, masterID lib.MasterID, config WorkerConfig) lib.Worker {
+		return fake.NewDummyWorker(ctx, id, masterID, config)
+	}
+	fac := NewSimpleWorkerFactory(dummyConstructor, &dummyConfig{})
+	config, err := fac.DeserializeConfig([]byte(`{"Val":1}`))
+	require.NoError(t, err)
+	require.Equal(t, &dummyConfig{Val: 1}, config)
+
+	newWorker, err := fac.NewWorker(dcontext.Background(), "my-worker", "my-master", &dummyConfig{Val: 1})
+	require.NoError(t, err)
+	require.IsType(t, &fake.Worker{}, newWorker)
+}

--- a/lib/registry/registry_test.go
+++ b/lib/registry/registry_test.go
@@ -9,15 +9,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var fakeWorkerFactory WorkerFactory = ConstructorFuncFactory(fake.NewDummyWorker)
+var (
+	_                 WorkerFactory = (*SimpleWorkerFactory)(nil)
+	fakeWorkerFactory WorkerFactory = NewSimpleWorkerFactory(fake.NewDummyWorker, &dummyConfig{})
+)
 
-const fakeWorkerType = lib.WorkerType(100)
+const (
+	fakeWorkerType = lib.WorkerType(100)
+)
+
+type dummyConfig struct {
+	Val int
+}
 
 func TestGlobalRegistry(t *testing.T) {
 	GlobalWorkerRegistry().MustRegisterWorkerType(fakeWorkerType, fakeWorkerFactory)
 
 	ctx := dcontext.Background()
-	worker, err := GlobalWorkerRegistry().CreateWorker(ctx, fakeWorkerType, "worker-1", "master-1")
+	worker, err := GlobalWorkerRegistry().CreateWorker(ctx, fakeWorkerType, "worker-1", "master-1", []byte(`{"Val":0}`))
 	require.NoError(t, err)
 	require.IsType(t, &fake.Worker{}, worker)
 	require.Equal(t, lib.WorkerID("worker-1"), worker.WorkerID())
@@ -39,6 +48,6 @@ func TestRegistryDuplicateType(t *testing.T) {
 func TestRegistryWorkerTypeNotFound(t *testing.T) {
 	registry := NewRegistry()
 	ctx := dcontext.Background()
-	_, err := registry.CreateWorker(ctx, fakeWorkerType, "worker-1", "master-1")
+	_, err := registry.CreateWorker(ctx, fakeWorkerType, "worker-1", "master-1", []byte(`{"Val"":0}`))
 	require.Error(t, err)
 }


### PR DESCRIPTION
- Registry now supports automatically unmarshalling worker configuration in `[]byte`