### PR TITLE
*: abstract some interfaces in server master, fix an executor panic

### DIFF
--- a/executor/server.go
+++ b/executor/server.go
@@ -250,12 +250,12 @@ func (s *Server) Run(ctx context.Context) error {
 	s.workerRtm = worker.NewRuntime(ctx)
 	s.workerRtm.Start(pollCon)
 
-	err = s.startMsgService(ctx, wg)
+	err = s.selfRegister(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = s.selfRegister(ctx)
+	err = s.startMsgService(ctx, wg)
 	if err != nil {
 		return err
 	}

--- a/servermaster/etcd_test.go
+++ b/servermaster/etcd_test.go
@@ -1,0 +1,54 @@
+package servermaster
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/hanfei1991/microcosm/pkg/etcdutils"
+	"github.com/phayes/freeport"
+	"github.com/pingcap/tiflow/dm/pkg/log"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/embed"
+)
+
+func init() {
+	err := log.InitLogger(&log.Config{Level: "warn"})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func allocTempURL(t *testing.T) string {
+	port, err := freeport.GetFreePort()
+	require.Nil(t, err)
+	return fmt.Sprintf("127.0.0.1:%d", port)
+}
+
+func TestStartEtcdTimeout(t *testing.T) {
+	t.Parallel()
+
+	name1 := "test-start-etcd-timeout-1"
+	name2 := "test-start-etcd-timeout-2"
+	dir, err := ioutil.TempDir("", name1)
+	require.Nil(t, err)
+
+	masterAddr := allocTempURL(t)
+	advertiseAddr := masterAddr
+	cfgCluster := &etcdutils.ConfigParams{}
+	cfgCluster.Name = name1
+	cfgCluster.DataDir = dir
+	peer1 := allocTempURL(t)
+	peer2 := allocTempURL(t)
+	cfgCluster.PeerUrls = "http://" + peer1
+	cfgCluster.InitialCluster = fmt.Sprintf("%s=http://%s,%s=http://%s", name1, peer1, name2, peer2)
+	cfgCluster.Adjust("", embed.ClusterStateFlagNew)
+
+	cfgClusterEtcd := etcdutils.GenEmbedEtcdConfigWithLogger("info")
+	cfgClusterEtcd, err = etcdutils.GenEmbedEtcdConfig(cfgClusterEtcd, masterAddr, advertiseAddr, cfgCluster)
+	require.Nil(t, err)
+
+	_, err = etcdutils.StartEtcd(cfgClusterEtcd, nil, nil, time.Millisecond*100)
+	require.EqualError(t, err, "[DFLOW:ErrMasterStartEmbedEtcdFail]start embed etcd timeout 100ms")
+}

--- a/servermaster/server.go
+++ b/servermaster/server.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/hanfei1991/microcosm/client"
-	"github.com/hanfei1991/microcosm/model"
 	"github.com/hanfei1991/microcosm/pb"
 	"github.com/hanfei1991/microcosm/pkg/adapter"
 	"github.com/hanfei1991/microcosm/pkg/errors"
@@ -50,8 +49,8 @@ type Server struct {
 	membership   Membership
 
 	// sched scheduler
-	executorManager *ExecutorManager
-	jobManager      *JobManager
+	executorManager ExecutorManager
+	jobManager      JobManager
 	//
 	cfg *Config
 
@@ -65,8 +64,7 @@ type Server struct {
 
 // NewServer creates a new master-server.
 func NewServer(cfg *Config, ctx *test.Context) (*Server, error) {
-	executorNotifier := make(chan model.ExecutorID, 100)
-	executorManager := NewExecutorManager(executorNotifier, cfg.KeepAliveTTL, cfg.KeepAliveInterval, ctx)
+	executorManager := NewExecutorManagerImpl(cfg.KeepAliveTTL, cfg.KeepAliveInterval, ctx)
 
 	urls, err := parseURLs(cfg.MasterAddr)
 	if err != nil {
@@ -76,7 +74,7 @@ func NewServer(cfg *Config, ctx *test.Context) (*Server, error) {
 	for _, u := range urls {
 		masterAddrs = append(masterAddrs, u.Host)
 	}
-	jobManager := NewJobManager(masterAddrs)
+	jobManager := NewJobManagerImpl(masterAddrs)
 
 	// messageServer := p2p.NewMessageServer(cfg.)
 


### PR DESCRIPTION
- Abstract interface `ExecutorManager` and `JobManager` in server master
- Fix a panic in executor caused by nil executor info
- Add one unit test in etcd startup function in server master package.