### PR TITLE
executor-manager: refine keepalive config, add unit tests

### DIFF
--- a/servermaster/config.go
+++ b/servermaster/config.go
@@ -97,7 +97,8 @@ type Config struct {
 	// NOTE: more items will be add when adding leader election
 	Etcd *etcdutils.ConfigParams `toml:"etcd" json:"etcd"`
 
-	KeepAliveTTLStr      string `toml:"keepalive-ttl" json:"keepalive-ttl"`
+	KeepAliveTTLStr string `toml:"keepalive-ttl" json:"keepalive-ttl"`
+	// time interval string to check executor aliveness
 	KeepAliveIntervalStr string `toml:"keepalive-interval" json:"keepalive-interval"`
 	RPCTimeoutStr        string `toml:"rpc-timeout" json:"rpc-timeout"`
 

--- a/servermaster/executor_manager_test.go
+++ b/servermaster/executor_manager_test.go
@@ -1,0 +1,60 @@
+package servermaster
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hanfei1991/microcosm/model"
+	"github.com/hanfei1991/microcosm/pb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutorManager(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	heartbeatTTL := time.Millisecond * 100
+	checkInterval := time.Millisecond * 10
+	mgr := NewExecutorManagerImpl(heartbeatTTL, checkInterval, nil)
+
+	// register an executor server
+	registerReq := &pb.RegisterExecutorRequest{
+		Address:    "127.0.0.1:10001",
+		Capability: 2,
+	}
+	info, err := mgr.AllocateNewExec(registerReq)
+	require.Nil(t, err)
+
+	mgr.mu.Lock()
+	require.Equal(t, 1, len(mgr.executors))
+	require.Contains(t, mgr.executors, info.ID)
+	mgr.mu.Unlock()
+
+	newHeartbeatReq := func() *pb.HeartbeatRequest {
+		return &pb.HeartbeatRequest{
+			ExecutorId: string(info.ID),
+			Status:     int32(model.Running),
+			Timestamp:  uint64(time.Now().Unix()),
+			Ttl:        uint64(10), // 10ms ttl
+		}
+	}
+
+	resp, err := mgr.HandleHeartbeat(newHeartbeatReq())
+	require.Nil(t, err)
+	require.Nil(t, resp.Err)
+
+	mgr.Start(ctx)
+
+	// sleep to wait executor heartbeat timeout
+	time.Sleep(time.Millisecond * 30)
+	mgr.mu.Lock()
+	require.Equal(t, 0, len(mgr.executors))
+	mgr.mu.Unlock()
+
+	resp, err = mgr.HandleHeartbeat(newHeartbeatReq())
+	require.Nil(t, err)
+	require.NotNil(t, resp.Err)
+	require.Equal(t, pb.ErrorCode_UnknownExecutor, resp.Err.GetCode())
+}

--- a/servermaster/executor_manager_test.go
+++ b/servermaster/executor_manager_test.go
@@ -20,8 +20,9 @@ func TestExecutorManager(t *testing.T) {
 	mgr := NewExecutorManagerImpl(heartbeatTTL, checkInterval, nil)
 
 	// register an executor server
+	executorAddr := "127.0.0.1:10001"
 	registerReq := &pb.RegisterExecutorRequest{
-		Address:    "127.0.0.1:10001",
+		Address:    executorAddr,
 		Capability: 2,
 	}
 	info, err := mgr.AllocateNewExec(registerReq)
@@ -41,9 +42,27 @@ func TestExecutorManager(t *testing.T) {
 		}
 	}
 
+	// test executor heartbeat
 	resp, err := mgr.HandleHeartbeat(newHeartbeatReq())
 	require.Nil(t, err)
 	require.Nil(t, resp.Err)
+
+	// test allocate resource to given task request
+	tasks := []*pb.ScheduleTask{
+		{
+			Task: &pb.TaskRequest{Id: 1, OpTp: int32(model.JobMasterType)},
+			Cost: 1,
+		},
+	}
+	allocated, allocResp := mgr.Allocate(tasks)
+	require.True(t, allocated)
+	require.Equal(t, 1, len(allocResp.GetSchedule()))
+	require.Equal(t, map[int64]*pb.ScheduleResult{
+		1: {
+			ExecutorId: string(info.ID),
+			Addr:       executorAddr,
+		},
+	}, allocResp.GetSchedule())
 
 	mgr.Start(ctx)
 
@@ -53,6 +72,7 @@ func TestExecutorManager(t *testing.T) {
 	require.Equal(t, 0, len(mgr.executors))
 	mgr.mu.Unlock()
 
+	// test late heartbeat request after executor is offline
 	resp, err = mgr.HandleHeartbeat(newHeartbeatReq())
 	require.Nil(t, err)
 	require.NotNil(t, resp.Err)

--- a/servermaster/executor_manager_test.go
+++ b/servermaster/executor_manager_test.go
@@ -67,7 +67,7 @@ func TestExecutorManager(t *testing.T) {
 	mgr.Start(ctx)
 
 	// sleep to wait executor heartbeat timeout
-	time.Sleep(time.Millisecond * 30)
+	time.Sleep(time.Millisecond * 50)
 	mgr.mu.Lock()
 	require.Equal(t, 0, len(mgr.executors))
 	mgr.mu.Unlock()


### PR DESCRIPTION
- Use `KeepAliveInterval` in server master as the executor aliveness check interval.
- Remove unused offline executor channel in executor manager.
- Add unit tests to executor manager.