### PR TITLE
master, worker: refine some API methods

### DIFF
--- a/executor/cvsTask/cvstask.go
+++ b/executor/cvsTask/cvstask.go
@@ -70,8 +70,8 @@ func (task *cvsTask) Tick(ctx context.Context) error {
 }
 
 // Status returns a short worker status to be periodically sent to the master.
-func (task *cvsTask) Status() (lib.WorkerStatus, error) {
-	return lib.WorkerStatus{Code: lib.WorkerStatusNormal, ErrorMessage: "", Ext: task.counter}, nil
+func (task *cvsTask) Status() lib.WorkerStatus {
+	return lib.WorkerStatus{Code: lib.WorkerStatusNormal, ErrorMessage: "", Ext: task.counter}
 }
 
 // Workload returns the current workload of the worker.
@@ -85,8 +85,9 @@ func (task *cvsTask) OnMasterFailover(reason lib.MasterFailoverReason) error {
 }
 
 // CloseImpl tells the WorkerImpl to quitrunStatusWorker and release resources.
-func (task *cvsTask) CloseImpl() {
+func (task *cvsTask) CloseImpl(ctx context.Context) error {
 	task.cancelFn()
+	return nil
 }
 
 func (task *cvsTask) Receive(ctx context.Context) error {

--- a/executor/worker/runtime.go
+++ b/executor/worker/runtime.go
@@ -87,7 +87,8 @@ func (r *Runtime) onWorkerFinish(worker lib.Worker, err error) {
 
 func (r *Runtime) closeWorker() {
 	for worker := range r.closingWorker {
-		worker.Close()
+		// TODO handle error
+		_ = worker.Close(context.TODO())
 		r.workerList.Delete(worker.WorkerID())
 	}
 }

--- a/executor/worker/runtime_test.go
+++ b/executor/worker/runtime_test.go
@@ -50,5 +50,6 @@ func (d *dummyWorker) Workload() model.RescUnit {
 	return model.RescUnit(1)
 }
 
-func (d *dummyWorker) Close() {
+func (d *dummyWorker) Close(ctx context.Context) error {
+	return nil
 }

--- a/lib/common.go
+++ b/lib/common.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -50,6 +51,10 @@ type WorkerStatus struct {
 	Code         WorkerStatusCode `json:"code"`
 	ErrorMessage string           `json:"error-message"`
 	Ext          interface{}      `json:"ext"`
+}
+
+type Closer interface {
+	Close(ctx context.Context) error
 }
 
 func HeartbeatPingTopic(masterID MasterID) p2p.Topic {

--- a/lib/fake/fake_worker.go
+++ b/lib/fake/fake_worker.go
@@ -43,11 +43,11 @@ func (d *dummyWorker) Tick(ctx context.Context) error {
 	return nil
 }
 
-func (d *dummyWorker) Status() (lib.WorkerStatus, error) {
+func (d *dummyWorker) Status() lib.WorkerStatus {
 	if d.init {
-		return lib.WorkerStatus{Code: lib.WorkerStatusNormal, Ext: d.tick}, nil
+		return lib.WorkerStatus{Code: lib.WorkerStatusNormal, Ext: d.tick}
 	}
-	return lib.WorkerStatus{Code: lib.WorkerStatusCreated}, nil
+	return lib.WorkerStatus{Code: lib.WorkerStatusCreated}
 }
 
 func (d *dummyWorker) Workload() model.RescUnit {
@@ -58,8 +58,9 @@ func (d *dummyWorker) OnMasterFailover(_ lib.MasterFailoverReason) error {
 	return nil
 }
 
-func (d *dummyWorker) CloseImpl() {
+func (d *dummyWorker) CloseImpl(ctx context.Context) error {
 	atomic.StoreInt32(&d.closed, 1)
+	return nil
 }
 
 func NewDummyWorker(ctx *dcontext.Context, id lib.WorkerID, masterID lib.MasterID, _ lib.WorkerConfig) lib.Worker {

--- a/lib/master.go
+++ b/lib/master.go
@@ -23,8 +23,9 @@ import (
 type Master interface {
 	Init(ctx context.Context) error
 	Poll(ctx context.Context) error
-	ID() MasterID
-	Close(ctx context.Context) error
+	MasterID() MasterID
+
+	Closer
 }
 
 type MasterImpl interface {
@@ -174,7 +175,7 @@ func (m *BaseMaster) Poll(ctx context.Context) error {
 	return nil
 }
 
-func (m *BaseMaster) ID() MasterID {
+func (m *BaseMaster) MasterID() MasterID {
 	return m.id
 }
 

--- a/lib/mock_worker_impl.go
+++ b/lib/mock_worker_impl.go
@@ -59,12 +59,12 @@ func (w *mockWorkerImpl) Tick(ctx context.Context) error {
 	return args.Error(0)
 }
 
-func (w *mockWorkerImpl) Status() (WorkerStatus, error) {
+func (w *mockWorkerImpl) Status() WorkerStatus {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
 	args := w.Called()
-	return args.Get(0).(WorkerStatus), args.Error(1)
+	return args.Get(0).(WorkerStatus)
 }
 
 func (w *mockWorkerImpl) OnMasterFailover(reason MasterFailoverReason) error {
@@ -77,9 +77,10 @@ func (w *mockWorkerImpl) OnMasterFailover(reason MasterFailoverReason) error {
 	return args.Error(0)
 }
 
-func (w *mockWorkerImpl) CloseImpl() {
+func (w *mockWorkerImpl) CloseImpl(ctx context.Context) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	w.Called()
+	args := w.Called()
+	return args.Error(0)
 }

--- a/lib/worker_test.go
+++ b/lib/worker_test.go
@@ -74,8 +74,9 @@ func TestWorkerInitAndClose(t *testing.T) {
 		},
 	}, statusMsg)
 
-	worker.On("CloseImpl")
-	worker.Close()
+	worker.On("CloseImpl").Return(nil)
+	err = worker.Close(ctx)
+	require.NoError(t, err)
 }
 
 const (


### PR DESCRIPTION
- Refined the interface methods of `Master` and `Worker`.
- Extracted `Closer` to define a common `Close` function on both `Master` and `Worker`.