### PR TITLE
test: fix executor timeout is not processed in time

### DIFF
--- a/servermaster/executor_manager_test.go
+++ b/servermaster/executor_manager_test.go
@@ -66,11 +66,11 @@ func TestExecutorManager(t *testing.T) {
 
 	mgr.Start(ctx)
 
-	// sleep to wait executor heartbeat timeout
-	time.Sleep(time.Millisecond * 50)
-	mgr.mu.Lock()
-	require.Equal(t, 0, len(mgr.executors))
-	mgr.mu.Unlock()
+	require.Eventually(t, func() bool {
+		mgr.mu.Lock()
+		defer mgr.mu.Unlock()
+		return len(mgr.executors) == 0
+	}, time.Second*2, time.Millisecond*50)
 
 	// test late heartbeat request after executor is offline
 	resp, err = mgr.HandleHeartbeat(newHeartbeatReq())


### PR DESCRIPTION
Fix unstable unit test

```
--- FAIL: TestExecutorManager (0.06s)
    executor_manager_test.go:72: 
        	Error Trace:	executor_manager_test.go:72
        	Error:      	Not equal: 
        	            	expected: 0
        	            	actual  : 1
        	Test:       	TestExecutorManager

FAIL	github.com/hanfei1991/microcosm/servermaster	4.444s
```