### PR TITLE
resource: make heartbeats update reserved resource

### DIFF
--- a/servermaster/executor_manager.go
+++ b/servermaster/executor_manager.go
@@ -103,7 +103,8 @@ func (e *ExecutorManagerImpl) HandleHeartbeat(req *pb.HeartbeatRequest) (*pb.Hea
 	exec.heartbeatTTL = time.Duration(req.Ttl) * time.Millisecond
 	exec.Status = model.ExecutorStatus(req.Status)
 	usage := model.RescUnit(req.GetResourceUsage())
-	err := e.rescMgr.Update(exec.ID, usage, exec.Status)
+	// TODO: update reserve resources by heartbeats.
+	err := e.rescMgr.Update(exec.ID, usage, usage, exec.Status)
 	if err != nil {
 		return nil, err
 	}

--- a/servermaster/resource/manager.go
+++ b/servermaster/resource/manager.go
@@ -17,7 +17,7 @@ type RescMgr interface {
 	Allocate(tasks []*pb.ScheduleTask) (bool, *pb.TaskSchedulerResponse)
 
 	// Update updates executor resource usage and running status
-	Update(id model.ExecutorID, use model.RescUnit, status model.ExecutorStatus) error
+	Update(id model.ExecutorID, used, reserved model.RescUnit, status model.ExecutorStatus) error
 }
 
 type ExecutorResource struct {

--- a/servermaster/resource/manager.go
+++ b/servermaster/resource/manager.go
@@ -26,11 +26,11 @@ type ExecutorResource struct {
 
 	// Capacity of the resource in this executor.
 	Capacity model.RescUnit
-	// Reserved resource in this node, meaning the max resource possible to use. 
+	// Reserved resource in this node, meaning the max resource possible to use.
 	// It's supposed to be the total cost of running tasks in this executor.
 	Reserved model.RescUnit
 	// Actually used resource in this node. It's supposed to be less than the reserved resource.
 	// But if the estimated reserved is not accurate, `Used` might be larger than `Reserved`.
-	Used     model.RescUnit
-	Addr     string
+	Used model.RescUnit
+	Addr string
 }

--- a/servermaster/resource/manager.go
+++ b/servermaster/resource/manager.go
@@ -24,8 +24,13 @@ type ExecutorResource struct {
 	ID     model.ExecutorID
 	Status model.ExecutorStatus
 
+	// Capacity of the resource in this executor.
 	Capacity model.RescUnit
+	// Reserved resource in this node, meaning the max resource possible to use. 
+	// It's supposed to be the total cost of running tasks in this executor.
 	Reserved model.RescUnit
+	// Actually used resource in this node. It's supposed to be less than the reserved resource.
+	// But if the estimated reserved is not accurate, `Used` might be larger than `Reserved`.
 	Used     model.RescUnit
 	Addr     string
 }


### PR DESCRIPTION
`Reserve` means the expected max resource usage of this node.
`Used` means the resource actually used of this node.
after decoupling resource manager and job master, both of used and reserved resources should be updated by heartbeats.