### PR TITLE
test: fix unstable unit test

### DIFF
--- a/executor/server_test.go
+++ b/executor/server_test.go
@@ -157,10 +157,12 @@ func TestDiscoveryKeepalive(t *testing.T) {
 		require.EqualError(t, err, context.Canceled.Error())
 	}()
 
+	var peers map[string]string
 	// check snapshot can be load when discovery keepalive routine starts for the first time
-	time.Sleep(time.Millisecond * 50)
-	peers := router.GetPeers()
-	require.Equal(t, 2, len(peers))
+	require.Eventually(t, func() bool {
+		peers = router.GetPeers()
+		return len(peers) == 2
+	}, time.Second, time.Millisecond*20)
 	require.Contains(t, peers, "uuid-1")
 	require.Contains(t, peers, "uuid-2")
 	require.Equal(t, int64(1), discoveryConnectTime.Load())

--- a/executor/server_test.go
+++ b/executor/server_test.go
@@ -187,8 +187,9 @@ func TestDiscoveryKeepalive(t *testing.T) {
 
 	// check will reconnect to discovery metastore when watch meets error
 	watchResp <- srvdiscovery.WatchResp{Err: stdErrors.New("mock discovery watch error")}
-	time.Sleep(time.Millisecond * 50)
-	require.Equal(t, int64(2), discoveryConnectTime.Load())
+	require.Eventually(t, func() bool {
+		return discoveryConnectTime.Load() == int64(2)
+	}, time.Second, time.Millisecond*20)
 
 	// check will reconnect to discovery metastore when metastore session is done
 	doneCh <- struct{}{}


### PR DESCRIPTION
Fix the following error

```golang
--- FAIL: TestDiscoveryKeepalive (0.09s)
    server_test.go:165: 
        	Error Trace:	server_test.go:165
        	Error:      	Not equal: 
        	            	expected: 2
        	            	actual  : 0
        	Test:       	TestDiscoveryKeepalive
[2022/01/26 09:26:22.150 +00:00] [ERROR] [http.go:26] ["debug server returned"] [error="mux: server closed"]
[2022/01/26 09:26:22.150 +00:00] [ERROR] [server.go:185] ["close tcp server"] [error="close tcp 127.0.0.1:40721: use of closed network connection"] [errorVerbose="close tcp 127.0.0.1:40721: use of closed network connection\ngithub.com/pingcap/errors.AddStack\n\t/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20211009033009-93128226aaa3/errors.go:174\ngithub.com/pingcap/errors.Trace\n\t/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20211009033009-93128226aaa3/juju_adaptor.go:15\ngithub.com/pingcap/tiflow/pkg/tcpserver.(*tcpServerImpl).Close\n\t/go/pkg/mod/github.com/pingcap/tiflow@v0.0.0-20211227085550-ccba0a4c362a/pkg/tcpserver/tcp_server.go:159\ngithub.com/hanfei1991/microcosm/executor.(*Server).Stop\n\t/home/circleci/project/executor/server.go:183\ngithub.com/hanfei1991/microcosm/executor.TestStartTCPSrv\n\t/home/circleci/project/executor/server_test.go:49\ntesting.tRunner\n\t/usr/local/go/src/testing/testing.go:1193\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1371"]
FAIL
coverage: 19.9% of statements
FAIL	github.com/hanfei1991/microcosm/executor	0.485s
```