### PR TITLE
master: fix worker offline detection

### DIFF
--- a/lib/master.go
+++ b/lib/master.go
@@ -241,20 +241,20 @@ func (m *BaseMaster) runWorkerCheck(ctx context.Context) error {
 		}
 
 		offlinedWorkers, onlinedWorkers := m.workerManager.Tick(ctx, m.messageRouter)
-		for _, workerInfo := range offlinedWorkers {
-			log.L().Info("worker is offline", zap.Any("worker-info", workerInfo))
-			tombstoneHandle := NewTombstoneWorkerHandle(workerInfo.ID, workerInfo.status)
-			err := m.Impl.OnWorkerOffline(tombstoneHandle, derror.ErrWorkerOffline.GenWithStackByArgs(workerInfo.ID))
-			if err != nil {
-				return errors.Trace(err)
-			}
-		}
-
 		for _, workerInfo := range onlinedWorkers {
 			log.L().Info("worker is online", zap.Any("worker-info", workerInfo))
 
 			handle := m.workerManager.GetWorkerHandle(workerInfo.ID)
 			err := m.Impl.OnWorkerOnline(handle)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+
+		for _, workerInfo := range offlinedWorkers {
+			log.L().Info("worker is offline", zap.Any("worker-info", workerInfo))
+			tombstoneHandle := NewTombstoneWorkerHandle(workerInfo.ID, workerInfo.status)
+			err := m.Impl.OnWorkerOffline(tombstoneHandle, derror.ErrWorkerOffline.GenWithStackByArgs(workerInfo.ID))
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/lib/master.go
+++ b/lib/master.go
@@ -241,6 +241,8 @@ func (m *BaseMaster) runWorkerCheck(ctx context.Context) error {
 		}
 
 		offlinedWorkers, onlinedWorkers := m.workerManager.Tick(ctx, m.messageRouter)
+		// It is logical to call `OnWorkerOnline` first and then call `OnWorkerOffline`.
+		// In case that these two events for the same worker is detected in the same tick.
 		for _, workerInfo := range onlinedWorkers {
 			log.L().Info("worker is online", zap.Any("worker-info", workerInfo))
 

--- a/lib/worker_manager.go
+++ b/lib/worker_manager.go
@@ -90,6 +90,9 @@ func (m *workerManagerImpl) Tick(
 
 	// respond to worker heartbeats
 	for workerID, workerInfo := range m.workerInfos {
+		// `justOnlined` indicates that the online event has not been notified,
+		// and `hasPendingHeartbeat` indicates that we have received a heartbeat and
+		// has not sent the Pong yet.
 		if workerInfo.justOnlined && workerInfo.hasPendingHeartbeat {
 			workerInfo.justOnlined = false
 			onlinedWorkers = append(onlinedWorkers, workerInfo)
@@ -105,6 +108,7 @@ func (m *workerManagerImpl) Tick(
 		}
 
 		if !workerInfo.hasPendingHeartbeat {
+			// No heartbeat to respond to.
 			continue
 		}
 		reply := &HeartbeatPongMessage{
@@ -128,6 +132,7 @@ func (m *workerManagerImpl) Tick(
 				zap.Any("message", reply))
 			continue
 		}
+		// We have sent the Pong, mark it as such.
 		workerInfo.hasPendingHeartbeat = false
 	}
 	return


### PR DESCRIPTION
- Fix the problem where an executor is offline and the `OnWorkerOfflined` method is not called for affected masters.