### PR TITLE
*: unify node info for server master and executor

### DIFF
--- a/executor/server.go
+++ b/executor/server.go
@@ -44,7 +44,7 @@ type Server struct {
 	sch         *runtime.Runtime
 	workerRtm   *worker.Runtime
 	msgServer   *p2p.MessageRPCService
-	info        *model.ExecutorInfo
+	info        *model.NodeInfo
 
 	lastHearbeatTime time.Time
 
@@ -447,7 +447,8 @@ func (s *Server) selfRegister(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	s.info = &model.ExecutorInfo{
+	s.info = &model.NodeInfo{
+		Type: model.NodeTypeExecutor,
 		ID:   model.ExecutorID(resp.ExecutorId),
 		Addr: s.cfg.WorkerAddr,
 	}

--- a/executor/server_test.go
+++ b/executor/server_test.go
@@ -148,8 +148,9 @@ func TestDiscoveryKeepalive(t *testing.T) {
 
 	router := &mockMessageRouter{peers: map[p2pImpl.NodeID]string{}}
 	s := &Server{
-		info: &model.ExecutorInfo{
-			ID: "uuid-1",
+		info: &model.NodeInfo{
+			Type: model.NodeTypeExecutor,
+			ID:   "uuid-1",
 		},
 		p2pMsgRouter: router,
 	}

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -6,9 +6,10 @@ import (
 	"github.com/hanfei1991/microcosm/pkg/adapter"
 )
 
-// NodeType is the node type, could be either server master or executor
+// NodeType is the type of a server instance, could be either server master or executor
 type NodeType int
 
+// All node types
 const (
 	NodeTypeServerMaster NodeType = iota + 1
 	NodeTypeExecutor
@@ -22,8 +23,8 @@ type DeployNodeID string
 
 type ExecutorID = DeployNodeID
 
-// NodeInfo describes deployment node information, the node could be server master.
-// or executor.
+// NodeInfo describes the information of server instance, contains node type, node
+// uuid, advertise address and capability(executor node only)
 type NodeInfo struct {
 	Type NodeType     `json:"type"`
 	ID   DeployNodeID `json:"id"`

--- a/model/cluster.go
+++ b/model/cluster.go
@@ -6,27 +6,39 @@ import (
 	"github.com/hanfei1991/microcosm/pkg/adapter"
 )
 
+// NodeType is the node type, could be either server master or executor
+type NodeType int
+
+const (
+	NodeTypeServerMaster NodeType = iota + 1
+	NodeTypeExecutor
+)
+
 // RescUnit is the min unit of resource that we count.
 type RescUnit int
 
-type ExecutorID string
+// DeployNodeID means the identify of a node
+type DeployNodeID string
 
-// ExecutorInfo describes an Executor.
-type ExecutorInfo struct {
-	ID   ExecutorID `json:"id"`
-	Addr string     `json:"addr"`
+type ExecutorID = DeployNodeID
+
+// NodeInfo describes deployment node information, the node could be server master.
+// or executor.
+type NodeInfo struct {
+	Type NodeType     `json:"type"`
+	ID   DeployNodeID `json:"id"`
+	Addr string       `json:"addr"`
+
 	// The capability of executor, including
 	// 1. cpu (goroutines)
 	// 2. memory
 	// 3. disk cap
 	// TODO: So we should enrich the cap dimensions in the future.
 	Capability int `json:"cap"`
-	// What kind of information do we need?
-	// LastHeartbeatTime int64
 }
 
-func (e *ExecutorInfo) EtcdKey() string {
-	return adapter.ExecutorInfoKeyAdapter.Encode(string(e.ID))
+func (e *NodeInfo) EtcdKey() string {
+	return adapter.NodeInfoKeyAdapter.Encode(string(e.ID))
 }
 
 type ExecutorStatus int32
@@ -39,7 +51,7 @@ const (
 	Busy
 )
 
-func (e *ExecutorInfo) ToJSON() (string, error) {
+func (e *NodeInfo) ToJSON() (string, error) {
 	data, err := json.Marshal(e)
 	if err != nil {
 		return "", err

--- a/pkg/adapter/keyadapter.go
+++ b/pkg/adapter/keyadapter.go
@@ -11,11 +11,11 @@ import (
 var (
 	MasterCampaignKey KeyAdapter = keyHexEncoderDecoder("/data-flow/master/leader")
 	// TODO: investigate whether we can merge MasterInfoKey and MasterMetaKey into one key
-	MasterInfoKey          KeyAdapter = keyHexEncoderDecoder("/data-flow/master/info")
-	MasterMetaKey          KeyAdapter = keyHexEncoderDecoder("/data-flow/master/meta")
-	ExecutorInfoKeyAdapter KeyAdapter = keyHexEncoderDecoder("/data-flow/executor/info")
-	JobKeyAdapter          KeyAdapter = keyHexEncoderDecoder("/data-flow/job")
-	TaskKeyAdapter         KeyAdapter = keyHexEncoderDecoder("/data-flow/task")
+	MasterInfoKey      KeyAdapter = keyHexEncoderDecoder("/data-flow/master/info")
+	MasterMetaKey      KeyAdapter = keyHexEncoderDecoder("/data-flow/master/meta")
+	NodeInfoKeyAdapter KeyAdapter = keyHexEncoderDecoder("/data-flow/node/info")
+	JobKeyAdapter      KeyAdapter = keyHexEncoderDecoder("/data-flow/job")
+	TaskKeyAdapter     KeyAdapter = keyHexEncoderDecoder("/data-flow/task")
 )
 
 type KeyAdapter interface {

--- a/pkg/srvdiscovery/etcd_impl_test.go
+++ b/pkg/srvdiscovery/etcd_impl_test.go
@@ -24,7 +24,7 @@ func init() {
 func TestEtcdDiscoveryAPI(t *testing.T) {
 	t.Parallel()
 
-	keyAdapter := adapter.ExecutorInfoKeyAdapter
+	keyAdapter := adapter.NodeInfoKeyAdapter
 	ctx, cancel := context.WithCancel(context.Background())
 	_, _, client, cleanFn := test.PrepareEtcd(t, "discovery-test1")
 	defer cleanFn()

--- a/pkg/srvdiscovery/interface.go
+++ b/pkg/srvdiscovery/interface.go
@@ -11,8 +11,8 @@ type (
 	UUID = string
 )
 
-// ServiceResource alias to ExecutorInfo
-type ServiceResource = model.ExecutorInfo
+// ServiceResource alias to NodeInfo
+type ServiceResource = model.NodeInfo
 
 // WatchResp defines the change set from a Watch API of Discovery interface
 type WatchResp struct {

--- a/pkg/srvdiscovery/runner.go
+++ b/pkg/srvdiscovery/runner.go
@@ -85,7 +85,7 @@ func (dr *DiscoveryRunnerImpl) connectToEtcdDiscovery(
 	// snapshot to the new one.
 	old := dr.snapshot.Clone()
 	dr.discovery = NewEtcdSrvDiscovery(
-		dr.etcdCli, adapter.ExecutorInfoKeyAdapter, dr.watchDur)
+		dr.etcdCli, adapter.NodeInfoKeyAdapter, dr.watchDur)
 
 	if len(old) > 0 {
 		dr.discovery.CopySnapshot(old)

--- a/pkg/srvdiscovery/runner_test.go
+++ b/pkg/srvdiscovery/runner_test.go
@@ -34,7 +34,7 @@ func TestDiscoveryRunner(t *testing.T) {
 			metadata.NewMetaEtcd(client),
 			3,
 			time.Millisecond*50,
-			adapter.ExecutorInfoKeyAdapter.Encode(string(res.ID)),
+			adapter.NodeInfoKeyAdapter.Encode(string(res.ID)),
 			resStr,
 		)
 	}

--- a/servermaster/campaign_test.go
+++ b/servermaster/campaign_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hanfei1991/microcosm/model"
 	"github.com/hanfei1991/microcosm/pkg/adapter"
 	"github.com/hanfei1991/microcosm/servermaster/cluster"
 	"github.com/hanfei1991/microcosm/test"
@@ -49,6 +50,7 @@ func TestLeaderLoopSuccess(t *testing.T) {
 		etcd:            etcd,
 		etcdClient:      client,
 		leaderServiceFn: mockLeaderService,
+		info:            &model.NodeInfo{ID: model.DeployNodeID(name)},
 	}
 	err := s.reset(ctx)
 	require.Nil(t, err)
@@ -93,6 +95,7 @@ func TestLeaderLoopMeetStaleData(t *testing.T) {
 		etcd:            etcd,
 		etcdClient:      client,
 		leaderServiceFn: mockLeaderService,
+		info:            &model.NodeInfo{ID: model.DeployNodeID(name)},
 	}
 
 	// simulate stale campaign data
@@ -141,6 +144,7 @@ func TestLeaderLoopWatchLeader(t *testing.T) {
 		cfg:        cfg,
 		etcd:       etcd,
 		etcdClient: client,
+		info:       &model.NodeInfo{ID: model.DeployNodeID(name)},
 	}
 
 	// Simulate another node campaigns to be leader, note we use another node

--- a/servermaster/executor_manager.go
+++ b/servermaster/executor_manager.go
@@ -20,8 +20,8 @@ import (
 type ExecutorManager interface {
 	HandleHeartbeat(req *pb.HeartbeatRequest) (*pb.HeartbeatResponse, error)
 	Allocate(tasks []*pb.ScheduleTask) (bool, *pb.TaskSchedulerResponse)
-	AllocateNewExec(req *pb.RegisterExecutorRequest) (*model.ExecutorInfo, error)
-	RegisterExec(info *model.ExecutorInfo)
+	AllocateNewExec(req *pb.RegisterExecutorRequest) (*model.NodeInfo, error)
+	RegisterExec(info *model.NodeInfo)
 	Start(ctx context.Context)
 }
 
@@ -113,10 +113,10 @@ func (e *ExecutorManagerImpl) HandleHeartbeat(req *pb.HeartbeatRequest) (*pb.Hea
 }
 
 // RegisterExec registers executor to both executor manager and resource manager
-func (e *ExecutorManagerImpl) RegisterExec(info *model.ExecutorInfo) {
+func (e *ExecutorManagerImpl) RegisterExec(info *model.NodeInfo) {
 	log.L().Info("register executor", zap.Any("info", info))
 	exec := &Executor{
-		ExecutorInfo:   *info,
+		NodeInfo:       *info,
 		lastUpdateTime: time.Now(),
 		heartbeatTTL:   e.initHeartbeatTTL,
 		Status:         model.Initing,
@@ -129,11 +129,11 @@ func (e *ExecutorManagerImpl) RegisterExec(info *model.ExecutorInfo) {
 
 // AllocateNewExec allocates new executor info to a give RegisterExecutorRequest
 // and then registers the executor.
-func (e *ExecutorManagerImpl) AllocateNewExec(req *pb.RegisterExecutorRequest) (*model.ExecutorInfo, error) {
+func (e *ExecutorManagerImpl) AllocateNewExec(req *pb.RegisterExecutorRequest) (*model.NodeInfo, error) {
 	log.L().Logger.Info("allocate new executor", zap.Stringer("req", req))
 
 	e.mu.Lock()
-	info := &model.ExecutorInfo{
+	info := &model.NodeInfo{
 		ID:         model.ExecutorID(e.idAllocator.AllocID()),
 		Addr:       req.Address,
 		Capability: int(req.Capability),
@@ -154,7 +154,7 @@ func (e *ExecutorManagerImpl) Allocate(tasks []*pb.ScheduleTask) (bool, *pb.Task
 
 // Executor records the status of an executor instance.
 type Executor struct {
-	model.ExecutorInfo
+	model.NodeInfo
 	Status model.ExecutorStatus
 
 	mu sync.Mutex
@@ -164,7 +164,7 @@ type Executor struct {
 }
 
 func (e *Executor) checkAlive() bool {
-	log.L().Logger.Info("check alive", zap.String("exec", string(e.ExecutorInfo.ID)))
+	log.L().Logger.Info("check alive", zap.String("exec", string(e.NodeInfo.ID)))
 
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/servermaster/failover.go
+++ b/servermaster/failover.go
@@ -13,7 +13,7 @@ import (
 // TODO: to make concurrent happens before semantic more accurate, we may introduce
 // some mechanisms such as cdc etcd_worker.
 func (s *Server) resetExecutor(ctx context.Context) error {
-	resp, err := s.etcdClient.Get(ctx, adapter.ExecutorInfoKeyAdapter.Path(), clientv3.WithPrefix())
+	resp, err := s.etcdClient.Get(ctx, adapter.NodeInfoKeyAdapter.Path(), clientv3.WithPrefix())
 	if err != nil {
 		return err
 	}
@@ -28,11 +28,13 @@ func (s *Server) resetExecutor(ctx context.Context) error {
 
 // resetExecHandle unmarshals executor info and resets related information
 func (s *Server) resetExecHandler(value []byte) error {
-	info := &model.ExecutorInfo{}
+	info := &model.NodeInfo{}
 	err := json.Unmarshal(value, info)
 	if err != nil {
 		return err
 	}
-	s.executorManager.RegisterExec(info)
+	if info.Type == model.NodeTypeExecutor {
+		s.executorManager.RegisterExec(info)
+	}
 	return nil
 }


### PR DESCRIPTION
Rename `ExecutorInfo` to `NodeInfo`, both server master and executor will store this meta in etcd, which is used in service discovery