### PR TITLE
worker: refine concurrency control of CreateWorker

### DIFF
--- a/lib/master.go
+++ b/lib/master.go
@@ -6,9 +6,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hanfei1991/microcosm/lib/quota"
-
 	"github.com/hanfei1991/microcosm/client"
+	"github.com/hanfei1991/microcosm/lib/quota"
 	"github.com/hanfei1991/microcosm/model"
 	"github.com/hanfei1991/microcosm/pb"
 	dcontext "github.com/hanfei1991/microcosm/pkg/context"

--- a/lib/quota/concurrency_quota.go
+++ b/lib/quota/concurrency_quota.go
@@ -1,0 +1,24 @@
+package quota
+
+import "golang.org/x/sync/semaphore"
+
+type ConcurrencyQuota interface {
+	TryConsume() bool
+	Release()
+}
+
+func NewConcurrencyQuota(total int64) ConcurrencyQuota {
+	return &concurrencyQuotaImpl{sem: semaphore.NewWeighted(total)}
+}
+
+type concurrencyQuotaImpl struct {
+	sem *semaphore.Weighted
+}
+
+func (c *concurrencyQuotaImpl) TryConsume() bool {
+	return c.sem.TryAcquire(1)
+}
+
+func (c *concurrencyQuotaImpl) Release() {
+	c.sem.Release(1)
+}

--- a/lib/quota/concurrency_quota_test.go
+++ b/lib/quota/concurrency_quota_test.go
@@ -1,0 +1,22 @@
+package quota
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcurrencyQuota(t *testing.T) {
+	t.Parallel()
+
+	quota := NewConcurrencyQuota(5)
+	require.True(t, quota.TryConsume())
+	require.True(t, quota.TryConsume())
+	require.True(t, quota.TryConsume())
+	require.True(t, quota.TryConsume())
+	require.True(t, quota.TryConsume())
+	require.False(t, quota.TryConsume())
+	quota.Release()
+	require.True(t, quota.TryConsume())
+	require.False(t, quota.TryConsume())
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -53,6 +53,7 @@ var (
 	ErrMasterNotFound                 = errors.Normalize("master is not found: master ID %s", errors.RFCCodeText("DFLOW:ErrMasterNotFound"))
 	ErrDuplicateWorkerID              = errors.Normalize("duplicate worker ID encountered: %s, report a bug", errors.RFCCodeText("DFLOW:ErrDuplicateWorkerID"))
 	ErrMasterClosed                   = errors.Normalize("master has been closed explicitly: master ID %s", errors.RFCCodeText("DFLOW:ErrMasterClosed"))
+	ErrMasterConcurrencyExceeded      = errors.Normalize("master has reached concurrency quota", errors.RFCCodeText("DFLOW:ErrMasterConcurrencyExceeded"))
 
 	ErrWorkerTypeNotFound = errors.Normalize("worker type is not found: type %d", errors.RFCCodeText("DFLOW:ErrWorkerTypeNotFound"))
 	ErrWorkerNotFound     = errors.Normalize("worker is not found: worker ID %s", errors.RFCCodeText("DFLOW:ErrWorkerNotFound"))


### PR DESCRIPTION
- Use new goroutines with a concurrency quota to run RPC calls needed by `CreateWorker`.