### PR TITLE
servermaster: reuse node info key to store server master info

### DIFF
--- a/servermaster/server.go
+++ b/servermaster/server.go
@@ -417,13 +417,6 @@ func (s *Server) reset(ctx context.Context) error {
 		return errors.Wrap(errors.ErrMasterNewServer, err)
 	}
 
-	// TODO: server master membership can share the same key with node info
-	_, err = s.etcdClient.Put(ctx, adapter.MasterInfoKey.Encode(s.name()),
-		s.cfg.String(), clientv3.WithLease(sess.Lease()))
-	if err != nil {
-		return errors.Wrap(errors.ErrEtcdAPIError, err)
-	}
-
 	// register NodeInfo key used in service discovery
 	value, err := s.info.ToJSON()
 	if err != nil {


### PR DESCRIPTION
Finish #129, server master and executor use the same node info key and form a cluster, and they can be distinguished from `NodeType`.