### PR TITLE
master/worker: fix worker status ext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.1.2
-	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
 	github.com/pingcap/errors v0.11.5-0.20211009033009-93128226aaa3

--- a/go.sum
+++ b/go.sum
@@ -1088,7 +1088,6 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/jobmaster/example/master_impl_test.go
+++ b/jobmaster/example/master_impl_test.go
@@ -79,7 +79,7 @@ func TestExampleMaster(t *testing.T) {
 		online := master.worker.online
 		master.worker.mu.Unlock()
 		return online
-	}, time.Second, 100*time.Millisecond)
+	}, 2*time.Second, 100*time.Millisecond)
 
 	// will be WorkerStatusInit after one heartbeat
 	err = master.Tick(ctx)

--- a/lib/common.go
+++ b/lib/common.go
@@ -89,6 +89,7 @@ func (s *WorkerStatus) fillExt(tpi interface{}) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	s.Ext = obj
 	return nil
 }
 

--- a/lib/common.go
+++ b/lib/common.go
@@ -7,11 +7,10 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/pingcap/errors"
-
 	"github.com/hanfei1991/microcosm/model"
 	"github.com/hanfei1991/microcosm/pkg/clock"
 	"github.com/hanfei1991/microcosm/pkg/p2p"
+	"github.com/pingcap/errors"
 )
 
 type (

--- a/lib/master_test.go
+++ b/lib/master_test.go
@@ -170,4 +170,18 @@ func TestMasterCreateWorker(t *testing.T) {
 	workerList := master.GetWorkers()
 	require.Len(t, workerList, 1)
 	require.Contains(t, workerList, workerID)
+
+	err = master.messageHandlerManager.InvokeHandler(t, StatusUpdateTopic(masterName, workerID1), masterName, &StatusUpdateMessage{
+		WorkerID: workerID1,
+		Status: WorkerStatus{
+			Code:     WorkerStatusNormal,
+			ExtBytes: []byte(`{"Val":4}`),
+		},
+	})
+	require.NoError(t, err)
+	status := master.GetWorkers()[workerID1].Status()
+	require.Equal(t, &WorkerStatus{
+		Code: WorkerStatusNormal,
+		Ext:  &dummyStatus{Val: 4},
+	}, status)
 }

--- a/lib/mock_master_impl.go
+++ b/lib/mock_master_impl.go
@@ -157,3 +157,11 @@ func (m *MockMasterImpl) CloseImpl(ctx context.Context) error {
 func (m *MockMasterImpl) MasterClient() *client.MockServerMasterClient {
 	return m.serverMasterClient
 }
+
+type dummyStatus struct {
+	Val int
+}
+
+func (m *MockMasterImpl) GetWorkerStatusExtTypeInfo() interface{} {
+	return &dummyStatus{}
+}

--- a/lib/worker.go
+++ b/lib/worker.go
@@ -442,6 +442,11 @@ func (m *masterClient) SendStatus(ctx context.Context, status WorkerStatus) erro
 		WorkerID: m.workerID,
 		Status:   status,
 	}
+
+	if err := statusUpdateMessage.Status.marshalExt(); err != nil {
+		return errors.Trace(err)
+	}
+
 	ok, err := m.messageSender.SendToNode(ctx, m.masterNode, StatusUpdateTopic(m.masterID, m.workerID), statusUpdateMessage)
 	if err != nil {
 		return errors.Trace(err)

--- a/lib/worker_test.go
+++ b/lib/worker_test.go
@@ -199,10 +199,6 @@ func TestWorkerMasterFailover(t *testing.T) {
 	}, time.Second*1, time.Millisecond*10)
 }
 
-type dummyStatus struct {
-	Val int
-}
-
 func TestWorkerStatus(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/lib/worker_test.go
+++ b/lib/worker_test.go
@@ -70,7 +70,8 @@ func TestWorkerInitAndClose(t *testing.T) {
 	require.Equal(t, &StatusUpdateMessage{
 		WorkerID: workerID1,
 		Status: WorkerStatus{
-			Code: WorkerStatusNormal,
+			Code:     WorkerStatusNormal,
+			ExtBytes: []byte("null"),
 		},
 	}, statusMsg)
 

--- a/lib/worker_test.go
+++ b/lib/worker_test.go
@@ -199,6 +199,51 @@ func TestWorkerMasterFailover(t *testing.T) {
 	}, time.Second*1, time.Millisecond*10)
 }
 
+type dummyStatus struct {
+	Val int
+}
+
+func TestWorkerStatus(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	worker := newMockWorkerImpl(workerID1, masterName)
+	worker.clock = clock.NewMock()
+	worker.clock.(*clock.Mock).Set(time.Now())
+	putMasterMeta(ctx, t, worker.metaKVClient, &MasterMetaKVData{
+		ID:          masterName,
+		NodeID:      masterNodeName,
+		Epoch:       1,
+		Initialized: true,
+	})
+
+	worker.On("InitImpl", mock.Anything).Return(nil)
+	worker.On("Status").Return(WorkerStatus{
+		Code: WorkerStatusNormal,
+		Ext: &dummyStatus{
+			Val: 1,
+		},
+	}, nil)
+	err := worker.Init(ctx)
+	require.NoError(t, err)
+
+	worker.clock.(*clock.Mock).Add(defaultTimeoutConfig.workerTimeoutDuration)
+	worker.clock.(*clock.Mock).Add(defaultTimeoutConfig.workerTimeoutDuration)
+
+	status, ok := worker.messageSender.TryPop(masterNodeName, StatusUpdateTopic(masterName, workerID1))
+	require.True(t, ok)
+	require.Equal(t, &StatusUpdateMessage{
+		WorkerID: workerID1,
+		Status: WorkerStatus{
+			Code: WorkerStatusNormal,
+			Ext: &dummyStatus{
+				Val: 1,
+			},
+			ExtBytes: []byte(`{"Val":1}`),
+		},
+	}, status)
+}
+
 func TestWorkerSuicide(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
- `WorkerStatus` has an `Ext` field which stores an object of a type customized by the business logic.
- In the previous design, the `json` library could not infer the actual type of the object, which could cause failure to deserialize the `WorkerStatus` or other unexpected consequences such as defaulting to `float64` when passing an integer value.
- The problem is solved by adding a method `GetWorkerStatusExtTypeInfo() interface{}` to `MasterImpl`, which provides the necessary type information for `WorkerStatus` to deserialize correctly.