### PR TITLE
common: fix panic because of reflect of invalid type

### DIFF
--- a/lib/common.go
+++ b/lib/common.go
@@ -78,13 +78,16 @@ type WorkerStatus struct {
 	Ext interface{} `json:"-"`
 }
 
-func (s *WorkerStatus) fillExt(tpi interface{}) error {
+func (s *WorkerStatus) fillExt(tpi interface{}) (err error) {
 	defer func() {
 		// ExtBytes is no longer useful after this function returns.
 		s.ExtBytes = nil
+		if r := recover(); r != nil {
+			err = errors.Errorf("fill ext failed: %v", r)
+		}
 	}()
 	obj := reflect.New(reflect.TypeOf(tpi).Elem()).Interface()
-	err := json.Unmarshal(s.ExtBytes, obj)
+	err = json.Unmarshal(s.ExtBytes, obj)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/lib/common.go
+++ b/lib/common.go
@@ -83,7 +83,7 @@ func (s *WorkerStatus) fillExt(tpi interface{}) (err error) {
 		// ExtBytes is no longer useful after this function returns.
 		s.ExtBytes = nil
 		if r := recover(); r != nil {
-			err = errors.Errorf("fill ext failed: %v", r)
+			err = errors.Errorf("Fill ext field of worker status failed: %v", r)
 		}
 	}()
 	obj := reflect.New(reflect.TypeOf(tpi).Elem()).Interface()

--- a/lib/common_test.go
+++ b/lib/common_test.go
@@ -1,0 +1,37 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type dummyExtField struct {
+	Id   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestWorkerStatusFillExt(t *testing.T) {
+	t.Parallel()
+
+	ws := &WorkerStatus{
+		ExtBytes: []byte(`{"id":10,"name":"test"}`),
+	}
+	err := ws.fillExt(&dummyExtField{})
+	require.Nil(t, err)
+	require.Equal(t, &dummyExtField{Id: 10, Name: "test"}, ws.Ext)
+
+	ws = &WorkerStatus{
+		ExtBytes: []byte("10"),
+	}
+	emptyInt := int64(0)
+	err = ws.fillExt(&emptyInt)
+	require.Nil(t, err)
+	require.Equal(t, int64(10), *ws.Ext.(*int64))
+
+	ws = &WorkerStatus{
+		ExtBytes: []byte("10"),
+	}
+	err = ws.fillExt(int64(0))
+	require.EqualError(t, err, "fill ext failed: reflect: Elem of invalid type int64")
+}

--- a/lib/common_test.go
+++ b/lib/common_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 type dummyExtField struct {
-	Id   int    `json:"id"`
+	ID   int    `json:"id"`
 	Name string `json:"name"`
 }
 
@@ -19,7 +19,7 @@ func TestWorkerStatusFillExt(t *testing.T) {
 	}
 	err := ws.fillExt(&dummyExtField{})
 	require.Nil(t, err)
-	require.Equal(t, &dummyExtField{Id: 10, Name: "test"}, ws.Ext)
+	require.Equal(t, &dummyExtField{ID: 10, Name: "test"}, ws.Ext)
 
 	ws = &WorkerStatus{
 		ExtBytes: []byte("10"),

--- a/lib/common_test.go
+++ b/lib/common_test.go
@@ -33,5 +33,5 @@ func TestWorkerStatusFillExt(t *testing.T) {
 		ExtBytes: []byte("10"),
 	}
 	err = ws.fillExt(int64(0))
-	require.EqualError(t, err, "fill ext failed: reflect: Elem of invalid type int64")
+	require.Regexp(t, ".*reflect: Elem of invalid type int64", err)
 }

--- a/lib/master.go
+++ b/lib/master.go
@@ -57,6 +57,7 @@ type MasterImpl interface {
 
 	// GetWorkerStatusExtTypeInfo returns an empty object that described the actual type
 	// of the `Ext` field in WorkerStatus.
+	// The returned type's kind must be Array, Chan, Map, Ptr, or Slice.
 	GetWorkerStatusExtTypeInfo() interface{}
 }
 
@@ -493,5 +494,6 @@ func (m *BaseMaster) CreateWorker(workerType WorkerType, config WorkerConfig, co
 func (m *BaseMaster) GetWorkerStatusExtTypeInfo() interface{} {
 	// This function provides a trivial default implementation of
 	// GetWorkerStatusExtTypeInfo.
-	return int64(0)
+	info := int64(0)
+	return &info
 }

--- a/test/job_test.go
+++ b/test/job_test.go
@@ -79,6 +79,8 @@ func getBenchmarkServers(n int, c *C) []string {
 	return servers
 }
 
+// nolint: unused
+// This test is outdated, can be removed later
 func (t *testJobSuite) testPause(c *C) {
 	cluster := NewEmptyMiniCluster()
 	masterAddr, _, _, executorCtx := cluster.Start1M1E(c)

--- a/test/job_test.go
+++ b/test/job_test.go
@@ -79,7 +79,7 @@ func getBenchmarkServers(n int, c *C) []string {
 	return servers
 }
 
-func (t *testJobSuite) TestPause(c *C) {
+func (t *testJobSuite) testPause(c *C) {
 	cluster := NewEmptyMiniCluster()
 	masterAddr, _, _, executorCtx := cluster.Start1M1E(c)
 	client, err := client.NewMasterClient(context.Background(), []string{masterAddr})


### PR DESCRIPTION
Fix panic in fake master
```
panic: reflect: Elem of invalid type int64

goroutine 166 [running]:
reflect.(*rtype).Elem(0xfb5860, 0xa, 0xf84320)
        /home/apple/.gvm/gos/go1.16.4/src/reflect/type.go:915 +0x1a5
github.com/hanfei1991/microcosm/lib.(*WorkerStatus).fillExt(0xc00090f730, 0xfb5860, 0x1354878, 0x0, 0x0)
        /home/apple/work/code/pingcap/microcosm/lib/common.go:86 +0x90
github.com/hanfei1991/microcosm/lib.(*BaseMaster).registerHandlerForWorker.func2(0xc0005ea8d0, 0x24, 0xf84320, 0xc00090f720, 0xc00090f720, 0x0)
        /home/apple/work/code/pingcap/microcosm/lib/master.go:376 +0x65
github.com/pingcap/tiflow/pkg/p2p.(*MessageServer).AddHandler.func1(0x1383478, 0xc000090cc0, 0x1056d20, 0xc000970100, 0xc000090d10, 0xc0001629b0)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/github.com/pingcap/tiflow@v0.0.0-20211227085550-ccba0a4c362a/pkg/p2p/server.go:426 +0x209
github.com/pingcap/tiflow/pkg/workerpool.(*defaultEventHandle).AddEvent.func2(0x1383478, 0xc000090d00, 0x0, 0x0)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/github.com/pingcap/tiflow@v0.0.0-20211227085550-ccba0a4c362a/pkg/workerpool/pool_impl.go:140 +0x4c
github.com/pingcap/tiflow/pkg/workerpool.(*worker).run(0xc0000141b0, 0x1383478, 0xc000090d00, 0x0, 0x0)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/github.com/pingcap/tiflow@v0.0.0-20211227085550-ccba0a4c362a/pkg/workerpool/pool_impl.go:345 +0x3fb
github.com/pingcap/tiflow/pkg/workerpool.(*defaultPoolImpl).Run.func1(0x0, 0x0)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/github.com/pingcap/tiflow@v0.0.0-20211227085550-ccba0a4c362a/pkg/workerpool/pool_impl.go:67 +0x45
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc000028030, 0xc00000e438)
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
        /home/apple/.gvm/pkgsets/go1.16.4/global/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x66
```