### PR TITLE
runtime, lib: abstract out the interface Runnable

### DIFF
--- a/executor/cvsTask/cvstask.go
+++ b/executor/cvsTask/cvstask.go
@@ -79,7 +79,7 @@ func NewCvsTask(ctx *dcontext.Context, _workerID lib.WorkerID, masterID lib.Mast
 }
 
 func (task *cvsTask) InitImpl(ctx context.Context) error {
-	log.L().Info("init the task  ", zap.Any("task id :", task.WorkerID()))
+	log.L().Info("init the task  ", zap.Any("task id :", task.ID()))
 	ctx, task.cancelFn = context.WithCancel(ctx)
 	go func() {
 		err := task.Receive(ctx)

--- a/executor/server.go
+++ b/executor/server.go
@@ -149,8 +149,8 @@ func (s *Server) DispatchTask(ctx context.Context, req *pb.DispatchTaskRequest) 
 	newWorker, err := registry.GlobalWorkerRegistry().CreateWorker(
 		dctx,
 		lib.WorkerType(req.GetTaskTypeId()),
-		lib.WorkerID(req.GetWorkerId()),
-		lib.MasterID(req.GetMasterId()),
+		req.GetWorkerId(),
+		req.GetMasterId(),
 		req.GetTaskConfig())
 	if err != nil {
 		log.L().Error("Failed to create worker", zap.Error(err))

--- a/executor/worker/runtime_test.go
+++ b/executor/worker/runtime_test.go
@@ -18,7 +18,7 @@ func TestBasicFunc(t *testing.T) {
 	workerNum := 1000
 
 	for i := 0; i < workerNum; i++ {
-		id := lib.WorkerID("executor" + strconv.Itoa(i))
+		id := "executor" + strconv.Itoa(i)
 		rt.AddWorker(&dummyWorker{
 			id: id,
 		})
@@ -42,7 +42,7 @@ func (d *dummyWorker) Poll(ctx context.Context) error {
 	return nil
 }
 
-func (d *dummyWorker) WorkerID() lib.WorkerID {
+func (d *dummyWorker) ID() worker.RunnableID {
 	return d.id
 }
 

--- a/jobmaster/cvsJob/cvsJobMaster.go
+++ b/jobmaster/cvsJob/cvsJobMaster.go
@@ -3,6 +3,8 @@ package cvs
 import (
 	"context"
 
+	"github.com/hanfei1991/microcosm/executor/worker"
+
 	cvsTask "github.com/hanfei1991/microcosm/executor/cvsTask"
 	"github.com/hanfei1991/microcosm/lib"
 	"github.com/hanfei1991/microcosm/lib/registry"
@@ -173,7 +175,7 @@ func (jm *JobMaster) CloseImpl(ctx context.Context) error {
 	return nil
 }
 
-func (jm *JobMaster) WorkerID() lib.WorkerID {
+func (jm *JobMaster) ID() worker.RunnableID {
 	return jm.workerID
 }
 

--- a/lib/common.go
+++ b/lib/common.go
@@ -1,7 +1,6 @@
 package lib
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -14,13 +13,13 @@ import (
 )
 
 type (
-	MasterID         string
-	WorkerID         string
 	WorkerStatusCode int32
 	WorkerType       int64
 
 	Epoch        = int64
 	WorkerConfig = interface{}
+	MasterID     = string
+	WorkerID     = string
 )
 
 // Among these statuses, only WorkerStatusCreated is used by the framework
@@ -102,17 +101,13 @@ func (s *WorkerStatus) marshalExt() error {
 	return nil
 }
 
-type Closer interface {
-	Close(ctx context.Context) error
-}
-
 func HeartbeatPingTopic(masterID MasterID, workerID WorkerID) p2p.Topic {
-	return fmt.Sprintf("heartbeat-ping-%s-%s", string(masterID), string(workerID))
+	return fmt.Sprintf("heartbeat-ping-%s-%s", masterID, workerID)
 }
 
 func HeartbeatPongTopic(masterID MasterID, workerID WorkerID) p2p.Topic {
 	// TODO do we need hex-encoding here?
-	return fmt.Sprintf("heartbeat-pong-%s-%s", string(masterID), string(workerID))
+	return fmt.Sprintf("heartbeat-pong-%s-%s", masterID, workerID)
 }
 
 func WorkloadReportTopic(masterID MasterID) p2p.Topic {

--- a/lib/fake/fake_master.go
+++ b/lib/fake/fake_master.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 
+	"github.com/hanfei1991/microcosm/executor/worker"
+
 	"github.com/hanfei1991/microcosm/lib"
 	"github.com/hanfei1991/microcosm/model"
 	dcontext "github.com/hanfei1991/microcosm/pkg/context"
@@ -36,7 +38,7 @@ type Master struct {
 	pendingWorkerSet map[lib.WorkerID]int
 }
 
-func (m *Master) WorkerID() lib.WorkerID {
+func (m *Master) ID() worker.RunnableID {
 	return m.workerID
 }
 
@@ -73,7 +75,7 @@ OUT:
 			}
 			log.L().Info("CreateWorker called",
 				zap.Int("index", i),
-				zap.String("worker-id", string(workerID)))
+				zap.String("worker-id", workerID))
 			m.pendingWorkerSet[workerID] = i
 		}
 	}
@@ -93,7 +95,7 @@ func (m *Master) OnWorkerDispatched(worker lib.WorkerHandle, result error) error
 	}
 
 	log.L().Info("FakeMaster: OnWorkerDispatched",
-		zap.String("worker-id", string(worker.ID())),
+		zap.String("worker-id", worker.ID()),
 		zap.Error(result))
 
 	m.workerListMu.Lock()
@@ -102,7 +104,7 @@ func (m *Master) OnWorkerDispatched(worker lib.WorkerHandle, result error) error
 	idx, ok := m.pendingWorkerSet[worker.ID()]
 	if !ok {
 		log.L().Panic("OnWorkerDispatched is called with an unknown workerID",
-			zap.String("worker-id", string(worker.ID())))
+			zap.String("worker-id", worker.ID()))
 	}
 	delete(m.pendingWorkerSet, worker.ID())
 	m.workerList[idx] = worker
@@ -112,14 +114,14 @@ func (m *Master) OnWorkerDispatched(worker lib.WorkerHandle, result error) error
 
 func (m *Master) OnWorkerOnline(worker lib.WorkerHandle) error {
 	log.L().Info("FakeMaster: OnWorkerOnline",
-		zap.String("worker-id", string(worker.ID())))
+		zap.String("worker-id", worker.ID()))
 
 	return nil
 }
 
 func (m *Master) OnWorkerOffline(worker lib.WorkerHandle, reason error) error {
 	log.L().Info("FakeMaster: OnWorkerOffline",
-		zap.String("worker-id", string(worker.ID())),
+		zap.String("worker-id", worker.ID()),
 		zap.Error(reason))
 
 	// TODO handle offlined workers

--- a/lib/fake/fake_worker.go
+++ b/lib/fake/fake_worker.go
@@ -38,7 +38,7 @@ func (d *dummyWorker) Tick(ctx context.Context) error {
 		return errors.New("not yet init")
 	}
 
-	log.L().Info("FakeWorker: Tick", zap.String("worker-id", string(d.ID())))
+	log.L().Info("FakeWorker: Tick", zap.String("worker-id", d.ID()))
 	if atomic.LoadInt32(&d.closed) == 1 {
 		return nil
 	}

--- a/lib/master.go
+++ b/lib/master.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hanfei1991/microcosm/client"
+	runtime "github.com/hanfei1991/microcosm/executor/worker"
 	"github.com/hanfei1991/microcosm/lib/quota"
 	"github.com/hanfei1991/microcosm/model"
 	"github.com/hanfei1991/microcosm/pb"
@@ -15,6 +16,7 @@ import (
 	"github.com/hanfei1991/microcosm/pkg/metadata"
 	"github.com/hanfei1991/microcosm/pkg/p2p"
 	"github.com/hanfei1991/microcosm/pkg/uuid"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiflow/dm/pkg/log"
 	"github.com/pingcap/tiflow/pkg/workerpool"
@@ -27,7 +29,7 @@ type Master interface {
 	Poll(ctx context.Context) error
 	MasterID() MasterID
 
-	Closer
+	runtime.Closer
 }
 
 type MasterImpl interface {
@@ -401,7 +403,7 @@ func (m *BaseMaster) CreateWorker(workerType WorkerType, config WorkerConfig, co
 	}
 
 	// workerID is expected to be globally unique.
-	workerID := WorkerID(m.uuidGen.NewString())
+	workerID := m.uuidGen.NewString()
 
 	if !m.createWorkerQuota.TryConsume() {
 		return "", derror.ErrMasterConcurrencyExceeded.GenWithStackByArgs()
@@ -448,8 +450,8 @@ func (m *BaseMaster) CreateWorker(workerType WorkerType, config WorkerConfig, co
 			Req: &pb.DispatchTaskRequest{
 				TaskTypeId: int64(workerType),
 				TaskConfig: configBytes,
-				MasterId:   string(m.id),
-				WorkerId:   string(workerID),
+				MasterId:   m.id,
+				WorkerId:   workerID,
 			},
 		})
 		if err != nil {

--- a/lib/master_mock_util.go
+++ b/lib/master_mock_util.go
@@ -79,14 +79,14 @@ func MockBaseMasterCreateWorker(
 			Req: &pb.DispatchTaskRequest{
 				TaskTypeId: int64(workerType),
 				TaskConfig: configBytes,
-				MasterId:   string(masterID),
-				WorkerId:   string(workerID),
+				MasterId:   masterID,
+				WorkerId:   workerID,
 			},
 		}).Return(&client.ExecutorResponse{Resp: &pb.DispatchTaskResponse{
 		ErrorCode: 1,
 	}}, nil)
 
-	master.uuidGen.(*uuid.MockGenerator).Push(string(workerID))
+	master.uuidGen.(*uuid.MockGenerator).Push(workerID)
 }
 
 func MockBaseMasterWorkerHeartbeat(

--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -23,7 +23,7 @@ func NewMetadataClient(masterID MasterID, metaKVClient metadata.MetaKV) *Metadat
 }
 
 func (c *MetadataClient) Load(ctx context.Context) (*MasterMetaKVData, error) {
-	key := adapter.MasterMetaKey.Encode(string(c.masterID))
+	key := adapter.MasterMetaKey.Encode(c.masterID)
 	rawResp, err := c.metaKVClient.Get(ctx, key)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -46,7 +46,7 @@ func (c *MetadataClient) Load(ctx context.Context) (*MasterMetaKVData, error) {
 }
 
 func (c *MetadataClient) Store(ctx context.Context, data *MasterMetaKVData) error {
-	key := adapter.MasterMetaKey.Encode(string(c.masterID))
+	key := adapter.MasterMetaKey.Encode(c.masterID)
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
 		return errors.Trace(err)

--- a/lib/registry/registry_test.go
+++ b/lib/registry/registry_test.go
@@ -29,7 +29,7 @@ func TestGlobalRegistry(t *testing.T) {
 	worker, err := GlobalWorkerRegistry().CreateWorker(ctx, fakeWorkerType, "worker-1", "master-1", []byte(`{"Val":0}`))
 	require.NoError(t, err)
 	require.IsType(t, &fake.Worker{}, worker)
-	require.Equal(t, lib.WorkerID("worker-1"), worker.WorkerID())
+	require.Equal(t, lib.WorkerID("worker-1"), worker.ID())
 }
 
 func TestRegistryDuplicateType(t *testing.T) {

--- a/lib/worker.go
+++ b/lib/worker.go
@@ -5,11 +5,13 @@ import (
 	"sync"
 	"time"
 
+	runtime "github.com/hanfei1991/microcosm/executor/worker"
 	"github.com/hanfei1991/microcosm/model"
 	"github.com/hanfei1991/microcosm/pkg/clock"
 	derror "github.com/hanfei1991/microcosm/pkg/errors"
 	"github.com/hanfei1991/microcosm/pkg/metadata"
 	"github.com/hanfei1991/microcosm/pkg/p2p"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tiflow/dm/pkg/log"
 	cerror "github.com/pingcap/tiflow/pkg/errors"
@@ -19,10 +21,10 @@ import (
 type Worker interface {
 	Init(ctx context.Context) error
 	Poll(ctx context.Context) error
-	WorkerID() WorkerID
+	ID() runtime.RunnableID
 	Workload() model.RescUnit
 
-	Closer
+	runtime.Closer
 }
 
 type WorkerImpl interface {
@@ -88,10 +90,6 @@ func NewBaseWorker(
 		errCh: make(chan error, 1),
 		clock: clock.New(),
 	}
-}
-
-func (w *BaseWorker) ID() WorkerID {
-	return w.id
 }
 
 func (w *BaseWorker) Workload() model.RescUnit {
@@ -169,7 +167,7 @@ func (w *BaseWorker) Close(ctx context.Context) error {
 	return nil
 }
 
-func (w *BaseWorker) WorkerID() WorkerID {
+func (w *BaseWorker) ID() runtime.RunnableID {
 	return w.id
 }
 

--- a/lib/worker_manager.go
+++ b/lib/worker_manager.go
@@ -179,13 +179,13 @@ func (m *workerManagerImpl) UpdateStatus(msg *StatusUpdateMessage) {
 	info, ok := m.getWorkerInfo(msg.WorkerID)
 	if !ok {
 		log.L().Info("received status update for non-existing worker",
-			zap.String("master-id", string(m.masterID)),
+			zap.String("master-id", m.masterID),
 			zap.Any("msg", msg))
 		return
 	}
 	info.status = msg.Status
 	log.L().Debug("worker status updated",
-		zap.String("master-id", string(m.masterID)),
+		zap.String("master-id", m.masterID),
 		zap.Any("msg", msg))
 }
 

--- a/lib/worker_test.go
+++ b/lib/worker_test.go
@@ -6,11 +6,18 @@ import (
 	"testing"
 	"time"
 
+	runtime "github.com/hanfei1991/microcosm/executor/worker"
 	"github.com/hanfei1991/microcosm/pkg/adapter"
 	"github.com/hanfei1991/microcosm/pkg/clock"
 	"github.com/hanfei1991/microcosm/pkg/metadata"
+
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	_ Worker           = (*BaseWorker)(nil)
+	_ runtime.Runnable = (Worker)(nil)
 )
 
 func putMasterMeta(ctx context.Context, t *testing.T, metaclient metadata.MetaKV, metaData *MasterMetaKVData) {

--- a/servermaster/jobmanager_v2.go
+++ b/servermaster/jobmanager_v2.go
@@ -70,7 +70,7 @@ func (jm *JobManagerImplV2) SubmitJob(ctx context.Context, req *pb.SubmitJobRequ
 		resp.Err = errors.ToPBError(err)
 		return resp
 	}
-	resp.JobIdStr = string(id)
+	resp.JobIdStr = id
 
 	return resp
 }

--- a/servermaster/server.go
+++ b/servermaster/server.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/hanfei1991/microcosm/client"
-	"github.com/hanfei1991/microcosm/lib"
 	"github.com/hanfei1991/microcosm/model"
 	"github.com/hanfei1991/microcosm/pb"
 	"github.com/hanfei1991/microcosm/pkg/adapter"
@@ -459,7 +458,7 @@ func (s *Server) runLeaderService(ctx context.Context) (err error) {
 	if err != nil {
 		return
 	}
-	s.jobManager, err = NewJobManagerImplV2(ctx, lib.MasterID(s.name()),
+	s.jobManager, err = NewJobManagerImplV2(ctx, s.name(),
 		s.msgService.MakeHandlerManager(), clients, metadata.NewMetaEtcd(s.etcdClient))
 	if err != nil {
 		return


### PR DESCRIPTION
- Abstract out the interface `Runnable` which describes an entity that can be run by the runtime.
- Minor modifications to `Worker` interface.
- Minor adjustment of the type of `WorkerID`.
- Abstract out the interface `Workloader`, which describes an object that can report its workload.