### PR TITLE
runtime: refine the implementation

### DIFF
--- a/executor/server.go
+++ b/executor/server.go
@@ -158,7 +158,19 @@ func (s *Server) DispatchTask(ctx context.Context, req *pb.DispatchTaskRequest) 
 		return nil, err
 	}
 
-	s.workerRtm.AddWorker(newWorker)
+	if err := s.workerRtm.SubmitTask(newWorker); err != nil {
+		errCode := pb.DispatchTaskErrorCode_Other
+		if errors.ErrRuntimeReachedCapacity.Equal(err) {
+			errCode = pb.DispatchTaskErrorCode_NoResource
+		}
+
+		return &pb.DispatchTaskResponse{
+			ErrorCode:    errCode,
+			ErrorMessage: err.Error(),
+			WorkerId:     req.GetWorkerId(),
+		}, nil
+	}
+
 	return &pb.DispatchTaskResponse{
 		ErrorCode: pb.DispatchTaskErrorCode_OK,
 		WorkerId:  req.GetWorkerId(),
@@ -226,6 +238,10 @@ func (s *Server) startMsgService(ctx context.Context, wg *errgroup.Group) (err e
 	return nil
 }
 
+const (
+	defaultRuntimeCapacity = 65536 // TODO make this configurable
+)
+
 func (s *Server) Run(ctx context.Context) error {
 	if test.GetGlobalTestFlag() {
 		return s.startForTest(ctx)
@@ -240,8 +256,12 @@ func (s *Server) Run(ctx context.Context) error {
 	})
 
 	pollCon := s.cfg.PollConcurrency
-	s.workerRtm = worker.NewRuntime(ctx)
-	s.workerRtm.Start(pollCon)
+	s.workerRtm = worker.NewRuntime(ctx, defaultRuntimeCapacity)
+
+	wg.Go(func() error {
+		s.workerRtm.Start(ctx, pollCon)
+		return nil
+	})
 
 	err := s.selfRegister(ctx)
 	if err != nil {

--- a/executor/worker/internal/runnables.go
+++ b/executor/worker/internal/runnables.go
@@ -1,0 +1,67 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/pingcap/tiflow/dm/pkg/log"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+
+	"github.com/hanfei1991/microcosm/model"
+)
+
+type Closer interface {
+	Close(ctx context.Context) error
+}
+
+type Workloader interface {
+	Workload() model.RescUnit
+}
+
+type RunnableID = string
+
+type Runnable interface {
+	Init(ctx context.Context) error
+	Poll(ctx context.Context) error
+	ID() RunnableID
+
+	Closer
+}
+
+type RunnableStatus = int32
+
+const (
+	TaskSubmitted = RunnableStatus(iota + 1)
+	TaskRunning
+	TaskClosing
+)
+
+type RunnableContainer struct {
+	Runnable
+	status atomic.Int32
+}
+
+func WrapRunnable(runnable Runnable) *RunnableContainer {
+	return &RunnableContainer{
+		Runnable: runnable,
+		status:   *atomic.NewInt32(TaskSubmitted),
+	}
+}
+
+func (c *RunnableContainer) Status() RunnableStatus {
+	return c.status.Load()
+}
+
+func (c *RunnableContainer) OnInitialized() {
+	oldStatus := c.status.Swap(TaskRunning)
+	if oldStatus != TaskSubmitted {
+		log.L().Panic("unexpected status", zap.Int32("status", oldStatus))
+	}
+}
+
+func (c *RunnableContainer) OnStopped() {
+	oldStatus := c.status.Swap(TaskClosing)
+	if oldStatus != TaskRunning {
+		log.L().Panic("unexpected status", zap.Int32("status", oldStatus))
+	}
+}

--- a/executor/worker/runtime.go
+++ b/executor/worker/runtime.go
@@ -6,49 +6,51 @@ import (
 	"time"
 
 	"github.com/edwingeng/deque"
-	"github.com/hanfei1991/microcosm/model"
 	"github.com/pingcap/tiflow/dm/pkg/log"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
+
+	"github.com/hanfei1991/microcosm/executor/worker/internal"
+	"github.com/hanfei1991/microcosm/model"
+	derror "github.com/hanfei1991/microcosm/pkg/errors"
+)
+
+// Re-export types for public use
+type (
+	Runnable   = internal.Runnable
+	RunnableID = internal.RunnableID
+	Workloader = internal.Workloader
+	Closer     = internal.Closer
 )
 
 type Scheduler struct {
 	sync.Mutex
 
-	ctx              context.Context
-	queue            deque.Deque
-	onWorkerFinished func(Runnable, error)
-}
-
-type Closer interface {
-	Close(ctx context.Context) error
-}
-
-type Workloader interface {
-	Workload() model.RescUnit
-}
-
-type RunnableID = string
-
-type Runnable interface {
-	Init(ctx context.Context) error
-	Poll(ctx context.Context) error
-	ID() RunnableID
-
-	Closer
+	ctx            context.Context
+	queue          deque.Deque
+	onTaskFinished func(*internal.RunnableContainer, error)
 }
 
 const emptyRestDuration = 50 * time.Millisecond
 
-func (s *Scheduler) AddWorker(worker Runnable) {
+func (s *Scheduler) AddTask(task Runnable) {
 	s.Lock()
-	s.queue.PushBack(worker)
+	s.queue.PushBack(task)
 	s.Unlock()
 }
 
 func (s *Scheduler) Run(conn int) {
+	var wg sync.WaitGroup
+
 	for i := 0; i < conn; i++ {
-		go s.runImpl()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.runImpl()
+		}()
 	}
+
+	wg.Wait()
 }
 
 func (s *Scheduler) runImpl() {
@@ -65,82 +67,187 @@ func (s *Scheduler) runImpl() {
 			s.Unlock()
 			continue
 		}
-		worker := s.queue.PopFront().(Runnable)
+		task := s.queue.PopFront().(*internal.RunnableContainer)
 		s.Unlock()
-		if err := worker.Poll(s.ctx); err != nil {
-			s.onWorkerFinished(worker, err)
+		if err := task.Poll(s.ctx); err != nil {
+			s.onTaskFinished(task, err)
 			continue
 		}
-		// TODO: calculate workload
 
 		s.Lock()
-		s.queue.PushBack(worker)
+		s.queue.PushBack(task)
 		s.Unlock()
 	}
 }
 
-func NewRuntime(ctx context.Context) *Runtime {
+func NewRuntime(ctx context.Context, capacity int64) *Runtime {
 	rt := &Runtime{
-		ctx:           ctx,
-		closingWorker: make(chan Runnable, 1024),
-		initingWorker: make(chan Runnable, 1024),
-		scheduler:     Scheduler{ctx: ctx, queue: deque.NewDeque()},
+		closingTasks: make(chan *internal.RunnableContainer, capacity),
+		initingTasks: make(chan *internal.RunnableContainer, capacity),
+		scheduler:    Scheduler{ctx: ctx, queue: deque.NewDeque()},
+		capacity:     capacity,
 	}
-	rt.scheduler.onWorkerFinished = rt.onWorkerFinish
+	rt.scheduler.onTaskFinished = rt.onTaskFinished
 	return rt
 }
 
 type Runtime struct {
-	workerList sync.Map // map[lib.WorkerID]lib.Worker
+	taskList sync.Map // stores *internal.RunnableContainer
 	// We should abstract a schedule interface to implement different
-	// schedule algorithm. For now, we assume every worker consume similar
+	// schedule algorithm. For now, we assume every task consume similar
 	// poll time, so we expect go scheduler can produce a fair result.
-	scheduler     Scheduler
-	closingWorker chan Runnable
-	initingWorker chan Runnable
-	ctx           context.Context
+	scheduler    Scheduler
+	closingTasks chan *internal.RunnableContainer
+	initingTasks chan *internal.RunnableContainer
+
+	capacity int64
+
+	// taskNumMu protects taskNum from concurrent writes
+	// Reading from it does not require locking.
+	taskNumMu sync.Mutex
+	taskNum   atomic.Int64
 }
 
-func (r *Runtime) onWorkerFinish(worker Runnable, err error) {
-	log.L().Warn("Worker has finished",
-		zap.Any("worker-id", worker.ID()),
+func (r *Runtime) onTaskFinished(task *internal.RunnableContainer, err error) {
+	log.L().Warn("Task has finished",
+		zap.Any("worker-id", task.ID()),
 		zap.Error(err))
-	r.closingWorker <- worker
-}
+	task.OnStopped()
 
-func (r *Runtime) closeWorker() {
-	for worker := range r.closingWorker {
-		// TODO context and error handling
-		_ = worker.Close(context.Background())
-		r.workerList.Delete(worker.ID())
+	select {
+	case r.closingTasks <- task:
+	default:
+		log.L().Panic("closingTasks is blocked unexpectedly",
+			zap.Int64("capacity", r.capacity),
+			zap.Int64("task-num", r.taskNum.Load()),
+			zap.Int("chan-size", len(r.closingTasks)))
 	}
 }
 
-func (r *Runtime) initWorker() {
-	for worker := range r.initingWorker {
-		if err := worker.Init(r.ctx); err != nil {
-			r.onWorkerFinish(worker, err)
-		} else {
-			r.scheduler.AddWorker(worker)
+func (r *Runtime) closeTask(ctx context.Context) {
+	for {
+		var (
+			task *internal.RunnableContainer
+			ok   bool
+		)
+		select {
+		case <-ctx.Done():
+			return
+		case task, ok = <-r.closingTasks:
+		}
+
+		if !ok {
+			return
+		}
+		// TODO error handling
+		_ = task.Close(ctx)
+		r.taskList.Delete(task.ID())
+
+		r.taskNumMu.Lock()
+		newTaskNum := r.taskNum.Sub(1)
+		r.taskNumMu.Unlock()
+
+		if newTaskNum < 0 {
+			log.L().Panic("negative taskNum", zap.Int64("task-num", newTaskNum))
 		}
 	}
 }
 
-func (r *Runtime) Start(conn int) {
-	go r.closeWorker()
-	go r.initWorker()
-	r.scheduler.Run(conn)
+func (r *Runtime) initTask(ctx context.Context) {
+	for {
+		var (
+			task *internal.RunnableContainer
+			ok   bool
+		)
+
+		select {
+		case <-ctx.Done():
+			return
+		case task, ok = <-r.initingTasks:
+		}
+
+		if !ok {
+			return
+		}
+
+		if err := task.Init(ctx); err != nil {
+			r.onTaskFinished(task, err)
+		} else {
+			task.OnInitialized()
+			r.scheduler.AddTask(task)
+		}
+	}
 }
 
-func (r *Runtime) AddWorker(worker Runnable) {
-	r.workerList.Store(worker.ID(), worker)
-	r.initingWorker <- worker
+func (r *Runtime) Start(ctx context.Context, conn int) {
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r.closeTask(ctx)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r.initTask(ctx)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r.scheduler.Run(conn)
+	}()
+
+	wg.Wait()
+}
+
+func (r *Runtime) SubmitTask(task Runnable) error {
+	ok := func() bool {
+		// We use lock-protected writes instead of a lock-free algorithm
+		// to make the code more readable. Plus, SubmitTask should not be
+		// a bottleneck in the system, so there is no need to optimize
+		// for latency or throughput.
+
+		r.taskNumMu.Lock()
+		defer r.taskNumMu.Unlock()
+
+		taskNum := r.taskNum.Load()
+		if taskNum >= r.capacity {
+			return false
+		}
+		r.taskNum.Add(1)
+		return true
+	}()
+
+	if !ok {
+		return derror.ErrRuntimeReachedCapacity.GenWithStackByArgs(r.capacity)
+	}
+
+	wrappedtask := internal.WrapRunnable(task)
+	r.taskList.Store(task.ID(), wrappedtask)
+
+	select {
+	case r.initingTasks <- wrappedtask:
+	default:
+		log.L().Panic("initingTasks is blocked unexpectedly",
+			zap.Int64("capacity", r.capacity),
+			zap.Int64("task-num", r.taskNum.Load()),
+			zap.Int("chan-size", len(r.initingTasks)))
+	}
+	return nil
 }
 
 func (r *Runtime) Workload() model.RescUnit {
 	ret := model.RescUnit(0)
-	r.workerList.Range(func(_, value interface{}) bool {
-		workloader, ok := value.(Workloader)
+	r.taskList.Range(func(_, value interface{}) bool {
+		container := value.(*internal.RunnableContainer)
+		if container.Status() != internal.TaskRunning {
+			// Skip tasks that are not currently running
+			return true
+		}
+		workloader, ok := container.Runnable.(Workloader)
 		if !ok {
 			return true
 		}

--- a/executor/worker/runtime_test.go
+++ b/executor/worker/runtime_test.go
@@ -10,9 +10,8 @@ import (
 	"github.com/pingcap/errors"
 	"go.uber.org/atomic"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/hanfei1991/microcosm/model"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBasicFunc(t *testing.T) {

--- a/executor/worker/runtime_test.go
+++ b/executor/worker/runtime_test.go
@@ -1,37 +1,98 @@
-package worker_test
+package worker
 
 import (
 	"context"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
-	"github.com/hanfei1991/microcosm/executor/worker"
-	"github.com/hanfei1991/microcosm/lib"
+	"github.com/pingcap/errors"
+	"go.uber.org/atomic"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/hanfei1991/microcosm/model"
 )
 
 func TestBasicFunc(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	rt := worker.NewRuntime(ctx)
-	rt.Start(10)
-	workerNum := 1000
+	defer cancel()
 
+	rt := NewRuntime(ctx, 65535)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		rt.Start(ctx, 10)
+	}()
+
+	workerNum := 1000
 	for i := 0; i < workerNum; i++ {
 		id := "executor" + strconv.Itoa(i)
-		rt.AddWorker(&dummyWorker{
+		err := rt.SubmitTask(&dummyWorker{
 			id: id,
 		})
+		require.NoError(t, err)
 	}
 	time.Sleep(time.Second)
 	if rtwl := rt.Workload(); int(rtwl) != workerNum {
 		t.Error("not equal", rtwl, workerNum)
 	}
 	cancel()
+
+	wg.Wait()
+}
+
+func TestWorkerFinished(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rt := NewRuntime(ctx, 65535)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		rt.Start(ctx, 20)
+	}()
+
+	workerNum := 1000
+
+	var workers []*dummyWorker
+	for i := 0; i < workerNum; i++ {
+		id := "executor" + strconv.Itoa(i)
+		worker := &dummyWorker{
+			id: id,
+		}
+		workers = append(workers, worker)
+		err := rt.SubmitTask(worker)
+		require.NoError(t, err)
+	}
+
+	require.Eventually(t, func() bool {
+		return rt.taskNum.Load() == int64(workerNum)
+	}, 1*time.Second, 100*time.Millisecond)
+
+	for _, worker := range workers {
+		worker.SetFinished()
+	}
+
+	require.Eventually(t, func() bool {
+		t.Logf("taskNum %d", rt.taskNum.Load())
+		return rt.taskNum.Load() == 0
+	}, 10*time.Second, 100*time.Millisecond)
+
+	cancel()
+	wg.Wait()
 }
 
 type dummyWorker struct {
-	id lib.WorkerID
+	id RunnableID
+
+	needQuit atomic.Bool
 }
 
 func (d *dummyWorker) Init(ctx context.Context) error {
@@ -39,10 +100,13 @@ func (d *dummyWorker) Init(ctx context.Context) error {
 }
 
 func (d *dummyWorker) Poll(ctx context.Context) error {
+	if d.needQuit.Load() {
+		return errors.New("worker is finished")
+	}
 	return nil
 }
 
-func (d *dummyWorker) ID() worker.RunnableID {
+func (d *dummyWorker) ID() RunnableID {
 	return d.id
 }
 
@@ -52,4 +116,8 @@ func (d *dummyWorker) Workload() model.RescUnit {
 
 func (d *dummyWorker) Close(ctx context.Context) error {
 	return nil
+}
+
+func (d *dummyWorker) SetFinished() {
+	d.needQuit.Store(true)
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -77,6 +77,7 @@ var (
 	ErrTaskNotFound               = errors.Normalize("task %d is not found", errors.RFCCodeText("DFLOW:ErrTaskNotFound"))
 	ErrExecutorUnknownOperator    = errors.Normalize("operator type %d is unknown", errors.RFCCodeText("DFLOW:ErrOperatorUnknown"))
 	ErrExecutorSessionDone        = errors.Normalize("executor %s session done", errors.RFCCodeText("DFLOW:ErrExecutorSessionDone"))
+	ErrRuntimeReachedCapacity     = errors.Normalize("runtime has reached its capacity %d", errors.RFCCodeText("DFLOW:ErrRuntimeReachedCapacity"))
 
 	// planner related errors
 	ErrPlannerDAGDepthExceeded = errors.Normalize("dag depth exceeded: %d", errors.RFCCodeText("DFLOW:ErrPlannerDAGDepthExceeded"))


### PR DESCRIPTION
Fixed the following problem:
- Adding tasks to channels could block the entire runtime.
- `Workload()` could be called on uninitialized tasks.
- Goroutines are not waited for.
- Runtime cannot be canceled from outside.

Added feature:
- Added error type `ErrRuntimeReachedCapacity`

Other:
- Minor adjustment of code styling.