### PR TITLE
job-master: remove heartbeat in base master, use job master instead

### DIFF
--- a/jobmaster/example/master_impl_test.go
+++ b/jobmaster/example/master_impl_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 const (
-	jobManagerID = "job-manager"
-
 	masterID = "master"
 
 	executorNodeID = "node-exec"
@@ -23,7 +21,7 @@ const (
 
 func newExampleMaster() *exampleMaster {
 	self := &exampleMaster{}
-	self.DefaultBaseMaster = lib.MockBaseMaster(jobManagerID, masterID, self)
+	self.DefaultBaseMaster = lib.MockBaseMaster(masterID, self)
 	return self
 }
 

--- a/lib/base_jobmaster.go
+++ b/lib/base_jobmaster.go
@@ -39,7 +39,7 @@ func NewBaseJobMaster(
 	// `masterID` is always the ID of master role, against current object
 	// `workerID` is the ID of current object
 	baseMaster := NewBaseMaster(
-		ctx, masterImpl, "" /* job manager */, workerID, messageHandlerManager,
+		ctx, masterImpl, workerID, messageHandlerManager,
 		messageRouter, metaKVClient, executorClientManager, serverMasterClient)
 	baseWorker := NewBaseWorker(
 		workerImpl, messageHandlerManager, messageRouter, metaKVClient,

--- a/lib/base_jobmaster.go
+++ b/lib/base_jobmaster.go
@@ -39,11 +39,11 @@ func NewBaseJobMaster(
 	// `masterID` is always the ID of master role, against current object
 	// `workerID` is the ID of current object
 	baseMaster := NewBaseMaster(
-		ctx, masterImpl, masterID, workerID, messageHandlerManager, messageRouter,
-		metaKVClient, executorClientManager, serverMasterClient)
+		ctx, masterImpl, "" /* job manager */, workerID, messageHandlerManager,
+		messageRouter, metaKVClient, executorClientManager, serverMasterClient)
 	baseWorker := NewBaseWorker(
-		workerImpl, messageHandlerManager, messageRouter, metaKVClient, workerID,
-		"" /* masterID, job manager uses empty string */)
+		workerImpl, messageHandlerManager, messageRouter, metaKVClient,
+		workerID, masterID)
 	return &defaultBaseJobMaster{
 		master: baseMaster,
 		worker: baseWorker,

--- a/lib/master.go
+++ b/lib/master.go
@@ -106,10 +106,6 @@ type DefaultBaseMaster struct {
 	// closeCh is closed when the BaseMaster is exiting
 	closeCh chan struct{}
 
-	// read-only fields
-	// if this master is job master, masterID represents job manager id
-	// if this master is job manager, master ID is ""
-	masterID      MasterID
 	id            MasterID // id of this master
 	advertiseAddr string
 	nodeID        p2p.NodeID
@@ -125,7 +121,6 @@ type DefaultBaseMaster struct {
 func NewBaseMaster(
 	ctx *dcontext.Context,
 	impl MasterImpl,
-	masterID MasterID,
 	id MasterID,
 	messageHandlerManager p2p.MessageHandlerManager,
 	messageRouter p2p.MessageSender,
@@ -149,7 +144,6 @@ func NewBaseMaster(
 		executorClientManager: executorClientManager,
 		serverMasterClient:    serverMasterClient,
 		pool:                  workerpool.NewDefaultAsyncPool(4),
-		masterID:              masterID,
 		id:                    id,
 		clock:                 clock.New(),
 

--- a/lib/master.go
+++ b/lib/master.go
@@ -92,9 +92,7 @@ type DefaultBaseMaster struct {
 	serverMasterClient    client.MasterClient
 	pool                  workerpool.AsyncPool
 
-	// used to communicate with job manager in server master
-	masterClient *masterClient
-	clock        clock.Clock
+	clock clock.Clock
 
 	// workerManager maintains the list of all workers and
 	// their statuses.
@@ -181,29 +179,6 @@ func (m *DefaultBaseMaster) Init(ctx context.Context) error {
 	m.currentEpoch.Store(epoch)
 	m.workerManager = newWorkerManager(m.id, !isInit, epoch)
 
-	// job manager doesn't need to send heartbeat to anybody
-	if !m.isJobManager() {
-		m.masterClient = newMasterClient(
-			m.masterID,
-			m.id,
-			m.messageRouter,
-			m.metaKVClient,
-			m.clock.Mono(),
-			func() error {
-				// TODO: support job manager failover
-				return nil
-			},
-		)
-		err = m.registerHandlerForMaster(ctx)
-		if err != nil {
-			return err
-		}
-		err = m.masterClient.InitMasterInfoFromMeta(ctx)
-		if err != nil {
-			return err
-		}
-	}
-
 	m.startBackgroundTasks()
 
 	if isInit {
@@ -289,29 +264,6 @@ func (m *DefaultBaseMaster) startBackgroundTasks() {
 			m.OnError(err)
 		}
 	}()
-
-	// TODO: extract a heartbeat manager and reuses it in both lib/master and lib/worker
-	if !m.isJobManager() {
-		m.wg.Add(1)
-		go func() {
-			defer m.wg.Done()
-			if err := m.runHeartbeatWorker(cctx); err != nil {
-				m.OnError(err)
-			}
-		}()
-
-		m.wg.Add(1)
-		go func() {
-			defer m.wg.Done()
-			if err := m.runWatchDog(cctx); err != nil {
-				m.OnError(err)
-			}
-		}()
-	}
-}
-
-func (m *DefaultBaseMaster) isJobManager() bool {
-	return m.masterID == ""
 }
 
 func (m *DefaultBaseMaster) runWorkerCheck(ctx context.Context) error {
@@ -406,29 +358,6 @@ func (m *DefaultBaseMaster) markInitializedInMetadata(ctx context.Context) error
 		return errors.Trace(err)
 	}
 
-	return nil
-}
-
-func (m *DefaultBaseMaster) registerHandlerForMaster(ctx context.Context) error {
-	topic := HeartbeatPongTopic(m.masterClient.masterID, m.id)
-	ok, err := m.messageHandlerManager.RegisterHandler(
-		ctx,
-		topic,
-		&HeartbeatPongMessage{},
-		func(sender p2p.NodeID, value p2p.MessageValue) error {
-			msg := value.(*HeartbeatPongMessage)
-			log.L().Debug("heartbeat pong received",
-				zap.Any("msg", msg))
-			m.masterClient.HandleHeartbeat(sender, msg)
-			return nil
-		})
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if !ok {
-		log.L().Panic("duplicate handler",
-			zap.String("topic", topic))
-	}
 	return nil
 }
 
@@ -590,37 +519,4 @@ func (m *DefaultBaseMaster) GetWorkerStatusExtTypeInfo() interface{} {
 	// GetWorkerStatusExtTypeInfo.
 	info := int64(0)
 	return &info
-}
-
-func (m *DefaultBaseMaster) runHeartbeatWorker(ctx context.Context) error {
-	ticker := m.clock.Ticker(m.timeoutConfig.workerHeartbeatInterval)
-	for {
-		select {
-		case <-ctx.Done():
-			return errors.Trace(ctx.Err())
-		case <-ticker.C:
-			if err := m.masterClient.SendHeartBeat(ctx, m.clock); err != nil {
-				return errors.Trace(err)
-			}
-		}
-	}
-}
-
-func (m *DefaultBaseMaster) runWatchDog(ctx context.Context) error {
-	ticker := m.clock.Ticker(m.timeoutConfig.workerHeartbeatInterval)
-	for {
-		select {
-		case <-ctx.Done():
-			return errors.Trace(ctx.Err())
-		case <-ticker.C:
-		}
-
-		isNormal, err := m.masterClient.CheckMasterTimeout(ctx, m.clock)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if !isNormal {
-			return derror.ErrWorkerSuicide.GenWithStackByArgs()
-		}
-	}
 }

--- a/lib/master_mock_util.go
+++ b/lib/master_mock_util.go
@@ -19,13 +19,12 @@ import (
 	"github.com/hanfei1991/microcosm/pkg/uuid"
 )
 
-func MockBaseMaster(masterID MasterID, id MasterID, masterImpl MasterImpl) *DefaultBaseMaster {
+func MockBaseMaster(id MasterID, masterImpl MasterImpl) *DefaultBaseMaster {
 	ret := NewBaseMaster(
 		// ctx is nil for now
 		// TODO refine this
 		nil,
 		masterImpl,
-		masterID,
 		id,
 		p2p.NewMockMessageHandlerManager(),
 		p2p.NewMockMessageSender(),

--- a/lib/mock_master_impl.go
+++ b/lib/mock_master_impl.go
@@ -50,7 +50,6 @@ func NewMockMasterImpl(masterID, id MasterID) *MockMasterImpl {
 		// TODO refine this
 		nil,
 		ret,
-		masterID,
 		id,
 		ret.messageHandlerManager,
 		ret.messageSender,
@@ -71,7 +70,6 @@ func (m *MockMasterImpl) Reset() {
 	m.DefaultBaseMaster = NewBaseMaster(
 		nil,
 		m,
-		m.masterID,
 		m.id,
 		m.messageHandlerManager,
 		m.messageSender,

--- a/servermaster/jobmanager_v2.go
+++ b/servermaster/jobmanager_v2.go
@@ -96,7 +96,6 @@ func NewJobManagerImplV2(
 	impl.BaseMaster = lib.NewBaseMaster(
 		dctx,
 		impl,
-		masterID,
 		id,
 		impl.messageHandlerManager,
 		impl.messageSender,


### PR DESCRIPTION
- Remove `masterClient` and heartbeat logic in `BaseMaster`
- Now job master should implement the interface of `lib.BaseJobMaster`