### PR TITLE
master: support passing by master meta ext

### DIFF
--- a/executor/server.go
+++ b/executor/server.go
@@ -144,6 +144,17 @@ func (s *Server) DispatchTask(ctx context.Context, req *pb.DispatchTaskRequest) 
 	}
 	dctx.Environ.NodeID = p2p.NodeID(s.info.ID)
 	dctx.Environ.Addr = s.info.Addr
+	masterMeta := &lib.MasterMetaExt{
+		// GetWorkerId here returns id of current unit
+		ID:     req.GetWorkerId(),
+		Tp:     lib.WorkerType(req.GetTaskTypeId()),
+		Config: req.GetTaskConfig(),
+	}
+	metaBytes, err := masterMeta.Marshal()
+	if err != nil {
+		return nil, err
+	}
+	dctx.Environ.MasterMetaExt = metaBytes
 
 	newWorker, err := registry.GlobalWorkerRegistry().CreateWorker(
 		dctx,

--- a/lib/common.go
+++ b/lib/common.go
@@ -149,7 +149,6 @@ type WorkloadReportMessage struct {
 }
 
 type (
-	MasterMetaExt    = interface{}
 	MasterMetaKVData struct {
 		ID          MasterID   `json:"id"`
 		Addr        string     `json:"addr"`
@@ -158,7 +157,7 @@ type (
 		Initialized bool       `json:"initialized"`
 
 		// Ext holds business-specific data
-		Ext MasterMetaExt `json:"ext"`
+		MasterMetaExt *MasterMetaExt `json:"meta-ext"`
 	}
 )
 

--- a/lib/job.go
+++ b/lib/job.go
@@ -1,9 +1,24 @@
 package lib
 
-// JobMasterV2 holds the config of a job and used for failover
-type JobMasterV2 struct {
-	ID         MasterID    `json:"id"`
-	Tp         WorkerType  `json:"type"`
-	Ext        interface{} `json:"ext"`
-	Checkpoint []byte      `json:"checkpoint"`
+import (
+	"encoding/json"
+)
+
+// MasterMetaExt holds the config of a job and used for failover
+type MasterMetaExt struct {
+	ID MasterID   `json:"id"`
+	Tp WorkerType `json:"type"`
+
+	// config stores raw config from submit-job, the raw config can be
+	// reflected to real type via DeserializeConfig
+	Config     []byte `json:"config"`
+	Checkpoint []byte `json:"checkpoint"`
+}
+
+func (meta *MasterMetaExt) Marshal() ([]byte, error) {
+	return json.Marshal(meta)
+}
+
+func (meta *MasterMetaExt) Unmarshal(data []byte) error {
+	return json.Unmarshal(data, meta)
 }

--- a/lib/metadata_test.go
+++ b/lib/metadata_test.go
@@ -1,0 +1,48 @@
+package lib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hanfei1991/microcosm/pkg/metadata"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMasterMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	metaKVClient := metadata.NewMetaMock()
+	meta := []*MasterMetaKVData{
+		{
+			MasterMetaExt: &MasterMetaExt{
+				ID: JobManagerUUID,
+				Tp: JobManager,
+			},
+		},
+		{
+			MasterMetaExt: &MasterMetaExt{
+				ID: "master-1",
+				Tp: FakeJobMaster,
+			},
+		},
+		{
+			MasterMetaExt: &MasterMetaExt{
+				ID: "master-2",
+				Tp: FakeJobMaster,
+			},
+		},
+	}
+	for _, data := range meta {
+		cli := NewMasterMetadataClient(data.MasterMetaExt.ID, metaKVClient)
+		err := cli.Store(ctx, data)
+		require.Nil(t, err)
+	}
+	cli := NewMasterMetadataClient("job-manager", metaKVClient)
+	masters, err := cli.LoadAllMasters(ctx)
+	require.Nil(t, err)
+	require.Len(t, masters, 2)
+	for _, master := range masters {
+		require.Equal(t, FakeJobMaster, master.MasterMetaExt.Tp)
+	}
+}

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -93,6 +93,7 @@ type RuntimeDependencies struct {
 }
 
 type Environment struct {
-	NodeID p2p.NodeID
-	Addr   string
+	NodeID        p2p.NodeID
+	Addr          string
+	MasterMetaExt []byte
 }

--- a/servermaster/job_fsm.go
+++ b/servermaster/job_fsm.go
@@ -11,7 +11,7 @@ import (
 
 type jobHolder struct {
 	lib.WorkerHandle
-	*lib.JobMasterV2
+	*lib.MasterMetaExt
 }
 
 // JobFsm manages state of all job masters, job master state forms a finite-state
@@ -48,8 +48,8 @@ type JobFsm struct {
 	JobStats
 
 	jobsMu      sync.RWMutex
-	pendingJobs map[lib.MasterID]*lib.JobMasterV2
-	waitAckJobs map[lib.MasterID]*lib.JobMasterV2
+	pendingJobs map[lib.MasterID]*lib.MasterMetaExt
+	waitAckJobs map[lib.MasterID]*lib.MasterMetaExt
 	onlineJobs  map[lib.MasterID]*jobHolder
 }
 
@@ -62,19 +62,19 @@ type JobStats interface {
 
 func NewJobFsm() *JobFsm {
 	return &JobFsm{
-		pendingJobs: make(map[lib.MasterID]*lib.JobMasterV2),
-		waitAckJobs: make(map[lib.MasterID]*lib.JobMasterV2),
+		pendingJobs: make(map[lib.MasterID]*lib.MasterMetaExt),
+		waitAckJobs: make(map[lib.MasterID]*lib.MasterMetaExt),
 		onlineJobs:  make(map[lib.MasterID]*jobHolder),
 	}
 }
 
-func (fsm *JobFsm) JobDispatched(job *lib.JobMasterV2) {
+func (fsm *JobFsm) JobDispatched(job *lib.MasterMetaExt) {
 	fsm.jobsMu.Lock()
 	defer fsm.jobsMu.Unlock()
 	fsm.waitAckJobs[job.ID] = job
 }
 
-func (fsm *JobFsm) IterPendingJobs(dispatchJobFn func(job *lib.JobMasterV2) (string, error)) error {
+func (fsm *JobFsm) IterPendingJobs(dispatchJobFn func(job *lib.MasterMetaExt) (string, error)) error {
 	fsm.jobsMu.Lock()
 	defer fsm.jobsMu.Unlock()
 
@@ -101,8 +101,8 @@ func (fsm *JobFsm) JobOnline(worker lib.WorkerHandle) error {
 		return errors.ErrWorkerNotFound.GenWithStackByArgs(worker.ID())
 	}
 	fsm.onlineJobs[worker.ID()] = &jobHolder{
-		WorkerHandle: worker,
-		JobMasterV2:  cfg,
+		WorkerHandle:  worker,
+		MasterMetaExt: cfg,
 	}
 	delete(fsm.waitAckJobs, worker.ID())
 	return nil
@@ -117,7 +117,7 @@ func (fsm *JobFsm) JobOffline(worker lib.WorkerHandle) {
 		log.L().Warn("non-online worker offline, ignore it", zap.String("id", worker.ID()))
 		return
 	}
-	fsm.pendingJobs[worker.ID()] = job.JobMasterV2
+	fsm.pendingJobs[worker.ID()] = job.MasterMetaExt
 	delete(fsm.onlineJobs, worker.ID())
 }
 

--- a/servermaster/job_fsm.go
+++ b/servermaster/job_fsm.go
@@ -96,13 +96,13 @@ func (fsm *JobFsm) JobOnline(worker lib.WorkerHandle) error {
 	fsm.jobsMu.Lock()
 	defer fsm.jobsMu.Unlock()
 
-	cfg, ok := fsm.waitAckJobs[worker.ID()]
+	job, ok := fsm.waitAckJobs[worker.ID()]
 	if !ok {
 		return errors.ErrWorkerNotFound.GenWithStackByArgs(worker.ID())
 	}
 	fsm.onlineJobs[worker.ID()] = &jobHolder{
 		WorkerHandle:  worker,
-		MasterMetaExt: cfg,
+		MasterMetaExt: job,
 	}
 	delete(fsm.waitAckJobs, worker.ID())
 	return nil
@@ -125,11 +125,11 @@ func (fsm *JobFsm) JobDispatchFailed(worker lib.WorkerHandle) error {
 	fsm.jobsMu.Lock()
 	defer fsm.jobsMu.Unlock()
 
-	cfg, ok := fsm.waitAckJobs[worker.ID()]
+	job, ok := fsm.waitAckJobs[worker.ID()]
 	if !ok {
 		return errors.ErrWorkerNotFound.GenWithStackByArgs(worker.ID())
 	}
-	fsm.pendingJobs[worker.ID()] = cfg
+	fsm.pendingJobs[worker.ID()] = job
 	delete(fsm.waitAckJobs, worker.ID())
 	return nil
 }

--- a/servermaster/job_fsm_test.go
+++ b/servermaster/job_fsm_test.go
@@ -13,9 +13,9 @@ func TestJobFsmStateTrans(t *testing.T) {
 	fsm := NewJobFsm()
 
 	id := "fsm-test-job-master-1"
-	job := &lib.JobMasterV2{
-		ID:  id,
-		Ext: "simple config",
+	job := &lib.MasterMetaExt{
+		ID:     id,
+		Config: []byte("simple config"),
 	}
 	worker := lib.NewTombstoneWorkerHandle(id, lib.WorkerStatus{Code: lib.WorkerStatusNormal})
 
@@ -35,8 +35,8 @@ func TestJobFsmStateTrans(t *testing.T) {
 	require.Equal(t, 1, fsm.PendingJobCount())
 
 	// Tick, process pending jobs, Pending -> WaitAck
-	dispatchedJobs := make([]*lib.JobMasterV2, 0)
-	err = fsm.IterPendingJobs(func(job *lib.JobMasterV2) (string, error) {
+	dispatchedJobs := make([]*lib.MasterMetaExt, 0)
+	err = fsm.IterPendingJobs(func(job *lib.MasterMetaExt) (string, error) {
 		dispatchedJobs = append(dispatchedJobs, job)
 		return id, nil
 	})

--- a/servermaster/server.go
+++ b/servermaster/server.go
@@ -498,7 +498,7 @@ func (s *Server) runLeaderService(ctx context.Context) (err error) {
 		return
 	}
 	dctx.Environ.MasterMetaExt = masterMetaExtBytes
-	s.jobManager, err = NewJobManagerImplV2(dctx, "", s.name(),
+	s.jobManager, err = NewJobManagerImplV2(dctx, "", lib.JobManagerUUID,
 		s.msgService.MakeHandlerManager(), p2p.NewMessageSender(s.p2pMsgRouter),
 		clients, metadata.NewMetaEtcd(s.etcdClient))
 	if err != nil {

--- a/servermaster/server.go
+++ b/servermaster/server.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hanfei1991/microcosm/client"
+	"github.com/hanfei1991/microcosm/lib"
 	"github.com/hanfei1991/microcosm/model"
 	"github.com/hanfei1991/microcosm/pb"
 	"github.com/hanfei1991/microcosm/pkg/adapter"
@@ -488,6 +489,15 @@ func (s *Server) runLeaderService(ctx context.Context) (err error) {
 	dctx := dcontext.NewContext(ctx, log.L())
 	dctx.Environ.Addr = s.cfg.AdvertiseAddr
 	dctx.Environ.NodeID = s.name()
+	masterMetaExt := &lib.MasterMetaExt{
+		ID: lib.JobManagerUUID,
+		Tp: lib.JobManager,
+	}
+	masterMetaExtBytes, err := masterMetaExt.Marshal()
+	if err != nil {
+		return
+	}
+	dctx.Environ.MasterMetaExt = masterMetaExtBytes
 	s.jobManager, err = NewJobManagerImplV2(dctx, "", s.name(),
 		s.msgService.MakeHandlerManager(), p2p.NewMessageSender(s.p2pMsgRouter),
 		clients, metadata.NewMetaEtcd(s.etcdClient))


### PR DESCRIPTION
To support the job master recover in job manager failover scenario, we should persist enough information of job master.

This PR refactors the storage of `MasterMetaKVData`, renames `JobMasterV2` to `MasterMetaExt` and uses it as a defined type in `MasterMetaKVData`, the `config` defined in `MasterMetaExt` can be parsed by registered `DeserializeConfig` function.

We can use `MasterMetaExt` to restore a complete job.