### PR TITLE
lib/master: fix duplicated handler for status update topic

### DIFF
--- a/lib/master.go
+++ b/lib/master.go
@@ -384,7 +384,7 @@ func (m *DefaultBaseMaster) unregisterMessageHandler(ctx context.Context, worker
 		log.L().Warn("status update message handler is not removed", zap.String("topic", topic))
 	}
 
-	return nil
+	return m.workerManager.OnWorkerOffline(ctx, workerID)
 }
 
 func (m *DefaultBaseMaster) OnError(err error) {

--- a/lib/worker_manager.go
+++ b/lib/worker_manager.go
@@ -26,6 +26,7 @@ type workerManager interface {
 	Tick(ctx context.Context, sender p2p.MessageSender) (offlinedWorkers []*WorkerInfo, onlinedWorkers []*WorkerInfo)
 	HandleHeartbeat(msg *HeartbeatPingMessage, fromNode p2p.NodeID) error
 	OnWorkerCreated(ctx context.Context, id WorkerID, exeuctorNodeID p2p.NodeID) error
+	OnWorkerOffline(ctx context.Context, id WorkerID) error
 	GetWorkerInfo(id WorkerID) (*WorkerInfo, bool)
 	PutWorkerInfo(info *WorkerInfo) bool
 	MessageSender() p2p.MessageSender
@@ -322,6 +323,18 @@ func (m *workerManagerImpl) OnWorkerCreated(ctx context.Context, id WorkerID, ex
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+func (m *workerManagerImpl) OnWorkerOffline(ctx context.Context, id WorkerID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r, ok := m.statusReceivers[id]
+	if !ok {
+		log.L().Warn("worker not found in status receivers", zap.String("workerID", id))
+	}
+	topic := workerStatusUpdatedTopic(r.workerMetaClient.MasterID(), r.workerID)
+	_, err := r.messageHandlerManager.UnregisterHandler(ctx, topic)
+	return err
 }
 
 func (m *workerManagerImpl) MessageSender() p2p.MessageSender {

--- a/lib/worker_manager.go
+++ b/lib/worker_manager.go
@@ -331,6 +331,7 @@ func (m *workerManagerImpl) OnWorkerOffline(ctx context.Context, id WorkerID) er
 	r, ok := m.statusReceivers[id]
 	if !ok {
 		log.L().Warn("worker not found in status receivers", zap.String("workerID", id))
+		return nil
 	}
 	topic := workerStatusUpdatedTopic(r.workerMetaClient.MasterID(), r.workerID)
 	_, err := r.messageHandlerManager.UnregisterHandler(ctx, topic)


### PR DESCRIPTION
Fix the following panic. Worker status update handler is not removed after worker is offline.

```go
[2022/02/21 01:36:43.980 +08:00] [INFO] [master.go:616] ["Worker dispatched"] [response="error_code:OK worker_id:\"e14847a4-36ab-474b-82ba-fb0b42558f8e\" "]
[2022/02/21 01:36:43.981 +08:00] [PANIC] [status.go:247] ["duplicate handlers"] [topic=worker-status-updated-dataflow-engine-job-manager-e14847a4-36ab-474b-82ba-fb0b42558f8e] [stack="github.com/hanfei1991/microcosm/lib.(*StatusReceiver).Init\n\t/home/apple/work/code/microcosm/lib/status.go:247\ngithub.com/hanfei1991/microcosm/lib.(*workerManagerImpl).addWorker.func1\n\t/home/apple/work/code/microcosm/lib/worker_manager.go:284\ngithub.com/pingcap/tiflow/pkg/workerpool.(*asyncWorker).run\n\t/home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/github.com/pingcap/tiflow@v0.0.0-20220224093943-901ba1d0ff05/pkg/workerpool/async_pool_impl.go:166\ngithub.com/pingcap/tiflow/pkg/workerpool.(*defaultAsyncPoolImpl).Run.func2\n\t/home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/github.com/pingcap/tiflow@v0.0.0-20220224093943-901ba1d0ff05/pkg/workerpool/async_pool_impl.go:114\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57"]
panic: duplicate handlers

goroutine 288 [running]:
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc00040ca80, {0xc0017ff380, 0x1, 0x1})
        /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/go.uber.org/zap@v1.19.1/zapcore/entry.go:232 +0x446
go.uber.org/zap.(*Logger).Panic(0xc00088ca20, {0x1c2102f, 0xc000122008}, {0xc0017ff380, 0x1, 0x1})
        /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/go.uber.org/zap@v1.19.1/logger.go:230 +0x59
github.com/hanfei1991/microcosm/lib.(*StatusReceiver).Init(0xc0019a80d0, {0x1fac928, 0xc000122008})
        /home/apple/work/code/microcosm/lib/status.go:247 +0x2b8
github.com/hanfei1991/microcosm/lib.(*workerManagerImpl).addWorker.func1()
        /home/apple/work/code/microcosm/lib/worker_manager.go:284 +0x5b
github.com/pingcap/tiflow/pkg/workerpool.(*asyncWorker).run(0xc0004df1d0)
        /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/github.com/pingcap/tiflow@v0.0.0-20220224093943-901ba1d0ff05/pkg/workerpool/async_pool_impl.go:166 +0x23
github.com/pingcap/tiflow/pkg/workerpool.(*defaultAsyncPoolImpl).Run.func2()
        /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/github.com/pingcap/tiflow@v0.0.0-20220224093943-901ba1d0ff05/pkg/workerpool/async_pool_impl.go:114 +0x2a
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x67
created by golang.org/x/sync/errgroup.(*Group).Go
        /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x92
```