### PR TITLE
jobmanager: fix on master recovered is not called

### DIFF
--- a/servermaster/jobmanager.go
+++ b/servermaster/jobmanager.go
@@ -137,7 +137,12 @@ func NewJobManagerImplV2(
 		id,
 	)
 
-	err = lib.StoreMasterMeta(dctx.Context(), impl.MetaKVClient(), impl.MasterMeta())
+	// Note the meta data of job manager is not used, it is safe to overwrite it
+	// every time a new server master leader is elected. And we always mark the
+	// Initialized to true in order to trigger OnMasterRecovered of job manager.
+	meta := impl.MasterMeta()
+	meta.Initialized = true
+	err = lib.StoreMasterMeta(dctx.Context(), impl.MetaKVClient(), meta)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
After the refactor https://github.com/hanfei1991/microcosm/pull/193, job manager meta is always overwritten when a new job manager starts(after new server master leader is elected). The `OnMasterRecovered` of job manager is never called.

Since the meta data of job manager is not used, it is safe to overwrite it every time when a new server master leader is elected. And we always mark the Initialized to true in order to trigger `OnMasterRecovered` of job manager.