### PR TITLE
servermaster: add an uuid suffix to server master id

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -55,6 +55,7 @@ var (
 	ErrMasterClosed                   = errors.Normalize("master has been closed explicitly: master ID %s", errors.RFCCodeText("DFLOW:ErrMasterClosed"))
 	ErrMasterConcurrencyExceeded      = errors.Normalize("master has reached concurrency quota", errors.RFCCodeText("DFLOW:ErrMasterConcurrencyExceeded"))
 	ErrMasterInvalidMeta              = errors.Normalize("invalid master meta data: %s", errors.RFCCodeText("DFLOW:ErrMasterInvalidMeta"))
+	ErrInvalidServerMasterID          = errors.Normalize("invalid server master id: %s", errors.RFCCodeText("DFLOW:ErrInvalidServerMasterID"))
 
 	ErrWorkerTypeNotFound         = errors.Normalize("worker type is not found: type %d", errors.RFCCodeText("DFLOW:ErrWorkerTypeNotFound"))
 	ErrWorkerNotFound             = errors.Normalize("worker is not found: worker ID %s", errors.RFCCodeText("DFLOW:ErrWorkerNotFound"))

--- a/servermaster/campaign.go
+++ b/servermaster/campaign.go
@@ -44,9 +44,12 @@ func (s *Server) leaderLoop(ctx context.Context) error {
 				time.Sleep(retryInterval)
 				continue
 			}
-			if leader.Name == s.name() {
-				// this server is already a leader, which indicates there is some
-				// stale information, just delete the leadership and campaign again.
+			if leader.Name == s.name() || leader.AdvertiseAddr == s.cfg.AdvertiseAddr {
+				// - leader.Name == s.name() means this server should be leader
+				// - leader.AdvertiseAddr == s.cfg.AdvertiseAddr means the old leader
+				//   has the same advertise addr as current server
+				// Both of these two conditions indicate the existing information
+				// of leader campaign is stale, just delete it and campaign again.
 				log.L().Warn("found stale leader key, delete it and campaign later",
 					zap.ByteString("key", key), zap.ByteString("val", data))
 				_, err := s.etcdClient.Delete(ctx, string(key))

--- a/servermaster/campaign_test.go
+++ b/servermaster/campaign_test.go
@@ -90,7 +90,9 @@ func TestLeaderLoopMeetStaleData(t *testing.T) {
 	cfg := NewConfig()
 	cfg.Etcd.Name = name
 	cfg.AdvertiseAddr = addr
+	id := genServerMasterUUID(name)
 	s := &Server{
+		id:              id,
 		cfg:             cfg,
 		etcd:            etcd,
 		etcdClient:      client,
@@ -141,6 +143,7 @@ func TestLeaderLoopWatchLeader(t *testing.T) {
 	cfg.Etcd.Name = name
 	cfg.AdvertiseAddr = addr
 	s := &Server{
+		id:         genServerMasterUUID(name),
 		cfg:        cfg,
 		etcd:       etcd,
 		etcdClient: client,
@@ -154,6 +157,7 @@ func TestLeaderLoopWatchLeader(t *testing.T) {
 	cfg2.Etcd.Name = name + "-node-copy"
 	cfg2.AdvertiseAddr = addr
 	s2 := &Server{
+		id:  genServerMasterUUID(cfg2.Etcd.Name),
 		cfg: cfg2,
 	}
 	sess, err := concurrency.NewSession(client, concurrency.WithTTL(10))

--- a/servermaster/campaign_test.go
+++ b/servermaster/campaign_test.go
@@ -2,6 +2,7 @@ package servermaster
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -130,76 +131,102 @@ func TestLeaderLoopMeetStaleData(t *testing.T) {
 }
 
 // TestLeaderLoopWatchLeader tests a non-leader node enters LeaderLoop, finds an
-// existing leader can starts to watch leader.
+// existing leader can start to watch leader.
 func TestLeaderLoopWatchLeader(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	name := "server-master-leader-loop-watch-leader-test1"
-	addr, etcd, client, cleanFn := test.PrepareEtcd(t, name)
+	serverCount := 3
+	names := make([]string, 0, serverCount)
+	for i := 0; i < serverCount; i++ {
+		names = append(names, fmt.Sprintf("server-master-leader-loop-watch-leader-test-%d", i))
+	}
+	addrs, etcds, client, cleanFn := test.PrepareEtcdCluster(t, names)
 	defer cleanFn()
 
-	cfg := NewConfig()
-	cfg.Etcd.Name = name
-	cfg.AdvertiseAddr = addr
-	s := &Server{
-		id:         genServerMasterUUID(name),
-		cfg:        cfg,
-		etcd:       etcd,
-		etcdClient: client,
-		info:       &model.NodeInfo{ID: model.DeployNodeID(name)},
+	mockLeaderServiceFn := func(ctx context.Context) error {
+		<-ctx.Done()
+		return nil
 	}
 
-	// Simulate another node campaigns to be leader, note we use another node
-	// name but hack to use the same gRPC address(etcd endpoint) to support
-	// creating leader client connection from non-leader node.
-	cfg2 := NewConfig()
-	cfg2.Etcd.Name = name + "-node-copy"
-	cfg2.AdvertiseAddr = addr
-	s2 := &Server{
-		id:  genServerMasterUUID(cfg2.Etcd.Name),
-		cfg: cfg2,
+	servers := make([]*Server, 0, serverCount)
+	for i := range names {
+		cfg := NewConfig()
+		cfg.Etcd.Name = names[i]
+		cfg.AdvertiseAddr = addrs[i]
+		s := &Server{
+			id:         genServerMasterUUID(names[i]),
+			cfg:        cfg,
+			etcd:       etcds[i],
+			etcdClient: client,
+			info:       &model.NodeInfo{ID: model.DeployNodeID(names[i])},
+		}
+		s.leaderServiceFn = mockLeaderServiceFn
+		servers = append(servers, s)
 	}
-	sess, err := concurrency.NewSession(client, concurrency.WithTTL(10))
-	require.Nil(t, err)
-	election, err := cluster.NewEtcdElection(ctx, client, sess, cluster.EtcdElectionConfig{
-		CreateSessionTimeout: time.Second * 3,
-		TTL:                  time.Second * 10,
-		Prefix:               adapter.MasterCampaignKey.Path(),
-	})
-	require.Nil(t, err)
-	_, _, err = election.Campaign(ctx, s2.member(), time.Second*3)
-	require.Nil(t, err)
 
-	err = s.reset(ctx)
-	require.Nil(t, err)
-	s.leaderClient.RLock()
-	leaderCli := s.leaderClient.cli
-	s.leaderClient.RUnlock()
-	require.Nil(t, leaderCli)
+	leaderIndex := -1
+	for i, server := range servers {
+		if server.etcd.Server.Lead() == uint64(server.etcd.Server.ID()) {
+			leaderIndex = i
+			break
+		}
+	}
+	require.LessOrEqual(t, 0, leaderIndex)
+	require.LessOrEqual(t, leaderIndex, serverCount)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
+	wg.Add(serverCount)
 	go func() {
 		defer wg.Done()
-		err := s.leaderLoop(ctx)
+		leaderServer := servers[leaderIndex]
+		err := leaderServer.reset(ctx)
+		require.Nil(t, err)
+		err = leaderServer.leaderLoop(ctx)
 		require.EqualError(t, err, context.Canceled.Error())
 	}()
+	for i := 0; i < serverCount; i++ {
+		if i == leaderIndex {
+			continue
+		}
+		s := servers[i]
+		go func() {
+			defer wg.Done()
+			err := s.reset(ctx)
+			require.Nil(t, err)
 
-	// check s.watchLeader is called
-	require.Eventually(t, func() bool {
-		member, exists := s.checkLeader()
-		if !exists {
-			return false
+			// check leaderClient is not set
+			s.leaderClient.RLock()
+			leaderCli := s.leaderClient.cli
+			s.leaderClient.RUnlock()
+			require.Nil(t, leaderCli)
+
+			err = s.leaderLoop(ctx)
+			require.EqualError(t, err, context.Canceled.Error())
+		}()
+	}
+
+	// check s.watchLeader is called in non-leader node
+	for i := 0; i < serverCount; i++ {
+		if i == leaderIndex {
+			continue
 		}
-		if member.Name != s2.name() {
-			return false
-		}
-		s.leaderClient.RLock()
-		leaderCli := s.leaderClient.cli
-		s.leaderClient.RUnlock()
-		return leaderCli != nil
-	}, time.Second*2, time.Millisecond*20)
+		s := servers[i]
+		require.Eventually(t, func() bool {
+			member, exists := s.checkLeader()
+			if !exists {
+				return false
+			}
+			if member.Name != servers[leaderIndex].name() {
+				return false
+			}
+			s.leaderClient.RLock()
+			leaderCli := s.leaderClient.cli
+			s.leaderClient.RUnlock()
+			return leaderCli != nil
+		}, time.Second*2, time.Millisecond*20)
+
+	}
 
 	cancel()
 	wg.Wait()

--- a/servermaster/server_test.go
+++ b/servermaster/server_test.go
@@ -153,7 +153,8 @@ func TestCheckLeaderAndNeedForward(t *testing.T) {
 	cfg := NewConfig()
 	etcdName := "test-check-leader-and-need-forward"
 	cfg.Etcd.Name = etcdName
-	s := &Server{cfg: cfg}
+	id := genServerMasterUUID(etcdName)
+	s := &Server{id: id, cfg: cfg}
 	isLeader, needForward := s.isLeaderAndNeedForward(ctx)
 	require.False(t, isLeader)
 	require.False(t, needForward)
@@ -184,7 +185,7 @@ func TestCheckLeaderAndNeedForward(t *testing.T) {
 	s.leaderClient.Lock()
 	s.leaderClient.cli = &client.MasterClientImpl{}
 	s.leaderClient.Unlock()
-	s.leader.Store(&Member{Name: etcdName})
+	s.leader.Store(&Member{Name: id})
 	wg.Wait()
 }
 

--- a/test/etcd_utils.go
+++ b/test/etcd_utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,4 +57,76 @@ func PrepareEtcd(t *testing.T, name string) (string, *embed.Etcd, *clientv3.Clie
 	}
 
 	return advertiseAddr, etcd, client, cleanFn
+}
+
+func PrepareEtcdCluster(t *testing.T, names []string) (
+	advertiseAddrs []string,
+	embedEtcds []*embed.Etcd,
+	etcdCli *clientv3.Client,
+	cleanFn func(),
+) {
+	dirs := make([]string, 0, len(names))
+	cfgs := make([]*etcdutils.ConfigParams, 0, len(names))
+	initialCluster := make([]string, 0, len(names))
+	for _, name := range names {
+		dir, err := ioutil.TempDir("", name)
+		require.Nil(t, err)
+		dirs = append(dirs, dir)
+
+		advertiseAddr := allocTempURL(t)
+		advertiseAddrs = append(advertiseAddrs, advertiseAddr)
+
+		cfgCluster := &etcdutils.ConfigParams{}
+		cfgCluster.Name = name
+		cfgCluster.DataDir = dir
+		cfgCluster.PeerUrls = "http://" + allocTempURL(t)
+		cfgs = append(cfgs, cfgCluster)
+
+		initialCluster = append(initialCluster, fmt.Sprintf("%s=%s", name, cfgCluster.PeerUrls))
+	}
+	etcdCh := make(chan *embed.Etcd)
+	for idx, cfg := range cfgs {
+		cfg.InitialCluster = strings.Join(initialCluster, ",")
+		fmt.Printf("cfg: %+v\n", cfg)
+		cfg.Adjust("", embed.ClusterStateFlagNew)
+		cfgClusterEtcd := etcdutils.GenEmbedEtcdConfigWithLogger("info")
+		addr := advertiseAddrs[idx]
+		cfgClusterEtcd, err := etcdutils.GenEmbedEtcdConfig(cfgClusterEtcd, addr, addr, cfg)
+		require.Nil(t, err)
+		go func() {
+			etcd, err := etcdutils.StartEtcd(cfgClusterEtcd, nil, nil, time.Minute)
+			require.Nil(t, err)
+			etcdCh <- etcd
+		}()
+	}
+fetchLoop:
+	for {
+		select {
+		case etcd := <-etcdCh:
+			embedEtcds = append(embedEtcds, etcd)
+			if len(embedEtcds) == len(names) {
+				break fetchLoop
+			}
+		case <-time.After(time.Minute):
+			t.Error("etcd doesn't start in time")
+		}
+	}
+
+	var err error
+	etcdCli, err = clientv3.New(clientv3.Config{
+		Endpoints:   advertiseAddrs,
+		DialTimeout: 3 * time.Second,
+	})
+	require.Nil(t, err)
+
+	cleanFn = func() {
+		for _, dir := range dirs {
+			os.RemoveAll(dir)
+		}
+		for _, etcd := range embedEtcds {
+			etcd.Close()
+		}
+	}
+
+	return
 }


### PR DESCRIPTION
Before this PR, each server master uses its embed etcd name as server id, which has one problem in failover scenario.

In the p2p message server, each node should have an unique id, when a server restarts and uses the old id, the other message nodes will ignore all messages of this restarted server, these messages are treated as late messages and ignored.

This PR adds an uuid suffix to etcd name as the server master id.

PR still in wip, need to fix a message flood issue when server master restarts and leader belongs to the same node(same etcd name prefix).