### PR TITLE
servermaster: support checking wait ack job timeout and re-dispatch

### DIFF
--- a/lib/common.go
+++ b/lib/common.go
@@ -105,10 +105,6 @@ func WorkloadReportTopic(masterID MasterID) p2p.Topic {
 	return fmt.Sprintf("workload-report-%s", masterID)
 }
 
-func StatusUpdateTopic(masterID MasterID, workerID WorkerID) p2p.Topic {
-	return fmt.Sprintf("status-update-%s-%s", masterID, workerID)
-}
-
 type HeartbeatPingMessage struct {
 	SendTime     clock.MonotonicTime `json:"send-time"`
 	FromWorkerID WorkerID            `json:"from-worker-id"`

--- a/lib/master.go
+++ b/lib/master.go
@@ -388,15 +388,6 @@ func (m *DefaultBaseMaster) UnregisterWorker(ctx context.Context, workerID Worke
 		log.L().Warn("heartbeat message handler is not removed", zap.String("topic", topic))
 	}
 
-	topic = StatusUpdateTopic(m.id, workerID)
-	removed, err = m.messageHandlerManager.UnregisterHandler(ctx, topic)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if !removed {
-		log.L().Warn("status update message handler is not removed", zap.String("topic", topic))
-	}
-
 	return m.workerManager.OnWorkerOffline(ctx, workerID)
 }
 

--- a/lib/master.go
+++ b/lib/master.go
@@ -80,6 +80,8 @@ type BaseMaster interface {
 	OnError(err error)
 	// RegisterWorker registers worker handler only, the worker is expected to be running
 	RegisterWorker(ctx context.Context, workerID WorkerID) error
+	// UnregisterWorker unregisters worker handlers, this worker is expected to be offline
+	UnregisterWorker(ctx context.Context, workerID WorkerID) error
 	// CreateWorker registers worker handler and dispatches worker to executor
 	CreateWorker(workerType WorkerType, config WorkerConfig, cost model.RescUnit) (WorkerID, error)
 }
@@ -364,7 +366,7 @@ func (m *DefaultBaseMaster) runWorkerCheck(ctx context.Context) error {
 				)
 			}
 			tombstoneHandle := NewTombstoneWorkerHandle(workerInfo.ID, *status, nil)
-			err := m.unregisterMessageHandler(ctx, workerInfo.ID)
+			err := m.UnregisterWorker(ctx, workerInfo.ID)
 			if err != nil {
 				return err
 			}
@@ -376,7 +378,7 @@ func (m *DefaultBaseMaster) runWorkerCheck(ctx context.Context) error {
 	}
 }
 
-func (m *DefaultBaseMaster) unregisterMessageHandler(ctx context.Context, workerID WorkerID) error {
+func (m *DefaultBaseMaster) UnregisterWorker(ctx context.Context, workerID WorkerID) error {
 	topic := HeartbeatPingTopic(m.id, workerID)
 	removed, err := m.messageHandlerManager.UnregisterHandler(ctx, topic)
 	if err != nil {
@@ -561,7 +563,7 @@ func (m *DefaultBaseMaster) CreateWorker(workerType WorkerType, config WorkerCon
 			if needUnregisterWorkerHandler {
 				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 				defer cancel()
-				if err := m.unregisterMessageHandler(ctx, workerID); err != nil {
+				if err := m.UnregisterWorker(ctx, workerID); err != nil {
 					m.OnError(errors.Trace(err))
 				}
 			}

--- a/lib/status.go
+++ b/lib/status.go
@@ -310,7 +310,7 @@ func (r *StatusReceiver) Tick(ctx context.Context) error {
 }
 
 func (r *StatusReceiver) Close(ctx context.Context) error {
-	topic := StatusUpdateTopic(r.workerMetaClient.MasterID(), r.workerID)
+	topic := workerStatusUpdatedTopic(r.workerMetaClient.MasterID(), r.workerID)
 	ok, err := r.messageHandlerManager.UnregisterHandler(ctx, topic)
 	if err != nil {
 		return errors.Trace(err)

--- a/lib/worker_manager.go
+++ b/lib/worker_manager.go
@@ -388,8 +388,13 @@ func (m *workerManagerImpl) addWorker(id WorkerID, executorNodeID p2p.NodeID) er
 
 	if _, exists := m.tombstones[id]; exists {
 		if m.fsmState.Load() != workerManagerWaitingHeartbeats {
-			log.L().Panic("Discovered a worker whose status is not persisted",
-				zap.String("worker-id", id), zap.String("executor-id", executorNodeID))
+			// TODO: confirm whether this check is needed
+			// when the workerID doesn't change, such as failover of a job master,
+			// the check will be true here
+			log.L().Warn("Discovered a worker whose status is not persisted",
+				zap.String("worker-id", id), zap.String("executor-id", executorNodeID),
+				zap.Int32("fsm-state", m.fsmState.Load()),
+			)
 		}
 		delete(m.tombstones, id)
 	}

--- a/servermaster/config.go
+++ b/servermaster/config.go
@@ -40,6 +40,9 @@ const (
 	defaultCampaignTimeout    = 5 * time.Second
 	defaultDiscoverTicker     = 3 * time.Second
 	defaultMetricInterval     = 15 * time.Second
+	// TODO: make it configurable, and must be larger than the
+	// workerTimeoutDuration (15s by default) in executor
+	defaultWorkerTimeout = 16 * time.Second
 
 	defaultPeerUrls            = "http://127.0.0.1:8291"
 	defaultInitialClusterState = embed.ClusterStateFlagNew

--- a/servermaster/job_fsm.go
+++ b/servermaster/job_fsm.go
@@ -2,9 +2,11 @@ package servermaster
 
 import (
 	"sync"
+	"time"
 
 	"github.com/hanfei1991/microcosm/lib"
 	"github.com/hanfei1991/microcosm/pb"
+	"github.com/hanfei1991/microcosm/pkg/clock"
 	"github.com/hanfei1991/microcosm/pkg/errors"
 	"github.com/pingcap/tiflow/dm/pkg/log"
 	"go.uber.org/zap"
@@ -13,6 +15,7 @@ import (
 type jobHolder struct {
 	lib.WorkerHandle
 	*lib.MasterMetaKVData
+	waitAckStartTime time.Time
 }
 
 // JobFsm manages state of all job masters, job master state forms a finite-state
@@ -50,8 +53,9 @@ type JobFsm struct {
 
 	jobsMu      sync.RWMutex
 	pendingJobs map[lib.MasterID]*lib.MasterMetaKVData
-	waitAckJobs map[lib.MasterID]*lib.MasterMetaKVData
+	waitAckJobs map[lib.MasterID]*jobHolder
 	onlineJobs  map[lib.MasterID]*jobHolder
+	clocker     clock.Clock
 }
 
 // JobStats defines a statistics interface for JobFsm
@@ -62,8 +66,9 @@ type JobStats interface {
 func NewJobFsm() *JobFsm {
 	return &JobFsm{
 		pendingJobs: make(map[lib.MasterID]*lib.MasterMetaKVData),
-		waitAckJobs: make(map[lib.MasterID]*lib.MasterMetaKVData),
+		waitAckJobs: make(map[lib.MasterID]*jobHolder),
 		onlineJobs:  make(map[lib.MasterID]*jobHolder),
+		clocker:     clock.New(),
 	}
 }
 
@@ -78,14 +83,15 @@ func (fsm *JobFsm) QueryJob(jobID lib.MasterID) *pb.QueryJobResponse {
 		resp.Status = pb.QueryJobResponse_pending
 		return resp
 	}
-	meta, ok = fsm.waitAckJobs[jobID]
+	job, ok := fsm.waitAckJobs[jobID]
 	if ok {
+		meta = job.MasterMetaKVData
 		resp.Tp = int64(meta.Tp)
 		resp.Config = meta.Config
 		resp.Status = pb.QueryJobResponse_dispatched
 		return resp
 	}
-	job, ok := fsm.onlineJobs[jobID]
+	job, ok = fsm.onlineJobs[jobID]
 	resp.Status = pb.QueryJobResponse_online
 	if ok {
 		resp.Tp = int64(job.Tp)
@@ -128,7 +134,10 @@ func (fsm *JobFsm) QueryJob(jobID lib.MasterID) *pb.QueryJobResponse {
 func (fsm *JobFsm) JobDispatched(job *lib.MasterMetaKVData) {
 	fsm.jobsMu.Lock()
 	defer fsm.jobsMu.Unlock()
-	fsm.waitAckJobs[job.ID] = job
+	fsm.waitAckJobs[job.ID] = &jobHolder{
+		MasterMetaKVData: job,
+		waitAckStartTime: fsm.clocker.Now(),
+	}
 }
 
 func (fsm *JobFsm) IterPendingJobs(dispatchJobFn func(job *lib.MasterMetaKVData) (string, error)) error {
@@ -142,8 +151,30 @@ func (fsm *JobFsm) IterPendingJobs(dispatchJobFn func(job *lib.MasterMetaKVData)
 		}
 		delete(fsm.pendingJobs, oldJobID)
 		job.ID = id
-		fsm.waitAckJobs[id] = job
+		fsm.waitAckJobs[id] = &jobHolder{
+			MasterMetaKVData: job,
+			waitAckStartTime: fsm.clocker.Now(),
+		}
 		log.L().Info("job master recovered", zap.Any("job", job))
+	}
+
+	return nil
+}
+
+func (fsm *JobFsm) IterWaitAckJobs(dispatchJobFn func(job *lib.MasterMetaKVData) (string, error)) error {
+	fsm.jobsMu.Lock()
+	defer fsm.jobsMu.Unlock()
+
+	for id, job := range fsm.waitAckJobs {
+		duration := fsm.clocker.Since(job.waitAckStartTime)
+		if duration > defaultWorkerTimeout {
+			_, err := dispatchJobFn(job.MasterMetaKVData)
+			if err != nil {
+				return err
+			}
+			fsm.waitAckJobs[id].waitAckStartTime = fsm.clocker.Now()
+			log.L().Info("job master doesn't receive heartbeat in time, recreate it", zap.Any("job", job))
+		}
 	}
 
 	return nil
@@ -159,7 +190,7 @@ func (fsm *JobFsm) JobOnline(worker lib.WorkerHandle) error {
 	}
 	fsm.onlineJobs[worker.ID()] = &jobHolder{
 		WorkerHandle:     worker,
-		MasterMetaKVData: job,
+		MasterMetaKVData: job.MasterMetaKVData,
 	}
 	delete(fsm.waitAckJobs, worker.ID())
 	return nil
@@ -186,7 +217,7 @@ func (fsm *JobFsm) JobDispatchFailed(worker lib.WorkerHandle) error {
 	if !ok {
 		return errors.ErrWorkerNotFound.GenWithStackByArgs(worker.ID())
 	}
-	fsm.pendingJobs[worker.ID()] = job
+	fsm.pendingJobs[worker.ID()] = job.MasterMetaKVData
 	delete(fsm.waitAckJobs, worker.ID())
 	return nil
 }


### PR DESCRIPTION
Finish task-3 in #190 
- Export `UnregisterWorker` API in `BaseMaster` interface.
- Check job last ack duration, if it is larger than worker timeout, re create the job master.