### PR TITLE
worker: support worker finish in one direction

### DIFF
--- a/dm/dump_worker_test.go
+++ b/dm/dump_worker_test.go
@@ -90,10 +90,10 @@ func TestDumpWorker(t *testing.T) {
 	worker.BaseWorker = lib.MockBaseWorker(workerID, masterID, worker)
 
 	putMasterMeta(context.Background(), t, worker.MetaKVClient(), &lib.MasterMetaKVData{
-		ID:          masterID,
-		NodeID:      nodeID,
-		Epoch:       1,
-		Initialized: true,
+		ID:         masterID,
+		NodeID:     nodeID,
+		Epoch:      1,
+		StatusCode: lib.MasterStatusInit,
 	})
 
 	err = worker.Init(ctx)

--- a/dm/load_worker_test.go
+++ b/dm/load_worker_test.go
@@ -29,10 +29,10 @@ func TestLoadWorker(t *testing.T) {
 	worker.BaseWorker = lib.MockBaseWorker(workerID, masterID, worker)
 
 	putMasterMeta(context.Background(), t, worker.MetaKVClient(), &lib.MasterMetaKVData{
-		ID:          masterID,
-		NodeID:      nodeID,
-		Epoch:       1,
-		Initialized: true,
+		ID:         masterID,
+		NodeID:     nodeID,
+		Epoch:      1,
+		StatusCode: lib.MasterStatusInit,
 	})
 
 	err = worker.Init(ctx)

--- a/dm/sync_worker_test.go
+++ b/dm/sync_worker_test.go
@@ -72,10 +72,10 @@ func TestSyncWorker(t *testing.T) {
 	worker.BaseWorker = lib.MockBaseWorker(workerID, masterID, worker)
 
 	putMasterMeta(context.Background(), t, worker.MetaKVClient(), &lib.MasterMetaKVData{
-		ID:          masterID,
-		NodeID:      nodeID,
-		Epoch:       1,
-		Initialized: true,
+		ID:         masterID,
+		NodeID:     nodeID,
+		Epoch:      1,
+		StatusCode: lib.MasterStatusInit,
 	})
 
 	err = worker.Init(ctx)

--- a/executor/worker/runtime.go
+++ b/executor/worker/runtime.go
@@ -109,9 +109,11 @@ type Runtime struct {
 }
 
 func (r *Runtime) onTaskFinished(task *internal.RunnableContainer, err error) {
-	log.L().Warn("Task has finished",
-		zap.Any("worker-id", task.ID()),
-		zap.Error(err))
+	if err == nil || derror.ErrWorkerFinish.Equal(err) {
+		log.L().Info("task finished", zap.String("worker-id", task.ID()))
+	} else {
+		log.L().Warn("task failed", zap.String("worker-id", task.ID()), zap.Error(err))
+	}
 	task.OnStopped()
 
 	select {

--- a/lib/base_jobmaster_test.go
+++ b/lib/base_jobmaster_test.go
@@ -112,6 +112,12 @@ func (m *testJobMasterImpl) IsJobMasterImpl() {
 	panic("unreachable")
 }
 
+func (m *testJobMasterImpl) Status() WorkerStatus {
+	return WorkerStatus{
+		Code: WorkerStatusNormal,
+	}
+}
+
 func newBaseJobMasterForTests(impl JobMasterImpl) *DefaultBaseJobMaster {
 	params := masterParamListForTest{
 		MessageHandlerManager: p2p.NewMockMessageHandlerManager(),
@@ -176,6 +182,9 @@ func TestBaseJobMasterBasics(t *testing.T) {
 
 	jobMaster.On("CloseImpl", mock.Anything).Return(nil)
 	jobMaster.mu.Unlock()
+
+	err = jobMaster.Exit(ctx, jobMaster.Status(), nil)
+	require.Regexp(t, ".*DFLOW:ErrWorkerFinish.*", err)
 
 	err = jobMaster.Close(ctx)
 	require.NoError(t, err)

--- a/lib/common.go
+++ b/lib/common.go
@@ -16,6 +16,8 @@ type (
 	WorkerStatusCode int32
 	WorkerType       int64
 
+	MasterStatusCode int32
+
 	Epoch        = int64
 	WorkerConfig = interface{}
 	MasterID     = string
@@ -32,6 +34,13 @@ const (
 	WorkerStatusInit
 	WorkerStatusError
 	WorkerStatusFinished
+)
+
+// Job master statuses
+const (
+	MasterStatusUninit = MasterStatusCode(iota + 1)
+	MasterStatusInit
+	MasterStatusFinished
 )
 
 const (
@@ -125,12 +134,12 @@ type WorkloadReportMessage struct {
 
 type (
 	MasterMetaKVData struct {
-		ID          MasterID   `json:"id"`
-		Addr        string     `json:"addr"`
-		NodeID      p2p.NodeID `json:"node-id"`
-		Epoch       Epoch      `json:"epoch"`
-		Initialized bool       `json:"initialized"`
-		Tp          WorkerType `json:"type"`
+		ID         MasterID         `json:"id"`
+		Addr       string           `json:"addr"`
+		NodeID     p2p.NodeID       `json:"node-id"`
+		Epoch      Epoch            `json:"epoch"`
+		StatusCode MasterStatusCode `json:"status"`
+		Tp         WorkerType       `json:"type"`
 
 		// Config holds business-specific data
 		Config []byte `json:"config"`

--- a/lib/master_test.go
+++ b/lib/master_test.go
@@ -36,8 +36,9 @@ type dummyConfig struct {
 func prepareMeta(ctx context.Context, t *testing.T, metaclient metadata.MetaKV) {
 	masterKey := adapter.MasterMetaKey.Encode(masterName)
 	masterInfo := &MasterMetaKVData{
-		ID:     masterName,
-		NodeID: masterNodeName,
+		ID:         masterName,
+		NodeID:     masterNodeName,
+		StatusCode: MasterStatusUninit,
 	}
 	masterInfoBytes, err := json.Marshal(masterInfo)
 	require.NoError(t, err)
@@ -66,7 +67,7 @@ func TestMasterInit(t *testing.T) {
 	var masterData MasterMetaKVData
 	err = json.Unmarshal(resp.Kvs[0].Value, &masterData)
 	require.NoError(t, err)
-	require.True(t, masterData.Initialized)
+	require.Equal(t, MasterStatusInit, masterData.StatusCode)
 
 	master.On("CloseImpl", mock.Anything).Return(nil)
 	err = master.Close(ctx)

--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -38,7 +38,8 @@ func (c *MasterMetadataClient) Load(ctx context.Context) (*MasterMetaKVData, err
 	if len(resp.Kvs) == 0 {
 		// TODO refine handling the situation where the mata key does not exist at this point
 		masterMeta := &MasterMetaKVData{
-			ID: c.masterID,
+			ID:         c.masterID,
+			StatusCode: MasterStatusUninit,
 		}
 		return masterMeta, nil
 	}

--- a/lib/registry/factory_test.go
+++ b/lib/registry/factory_test.go
@@ -39,13 +39,13 @@ func TestNewSimpleWorkerFactory(t *testing.T) {
 	dummyConstructor := func(ctx *dcontext.Context, id lib.WorkerID, masterID lib.MasterID, config WorkerConfig) lib.WorkerImpl {
 		return fake.NewDummyWorker(ctx, id, masterID, config)
 	}
-	fac := NewSimpleWorkerFactory(dummyConstructor, &dummyConfig{})
-	config, err := fac.DeserializeConfig([]byte(`{"Val":1}`))
+	fac := NewSimpleWorkerFactory(dummyConstructor, &fake.WorkerConfig{})
+	config, err := fac.DeserializeConfig([]byte(`{"target-tick":100}`))
 	require.NoError(t, err)
-	require.Equal(t, &dummyConfig{Val: 1}, config)
+	require.Equal(t, &fake.WorkerConfig{TargetTick: 100}, config)
 
 	ctx := makeCtxWithMockDeps(t)
-	newWorker, err := fac.NewWorkerImpl(ctx, "my-worker", "my-master", &dummyConfig{Val: 1})
+	newWorker, err := fac.NewWorkerImpl(ctx, "my-worker", "my-master", &fake.WorkerConfig{TargetTick: 100})
 	require.NoError(t, err)
 	require.IsType(t, &fake.Worker{}, newWorker)
 }

--- a/lib/registry/register_fake.go
+++ b/lib/registry/register_fake.go
@@ -6,8 +6,6 @@ import (
 	dcontext "github.com/hanfei1991/microcosm/pkg/context"
 )
 
-type FakeConfig struct{}
-
 // only for test.
 func RegisterFake(registry Registry) {
 	fakeMasterFactory := NewSimpleWorkerFactory(func(ctx *dcontext.Context, id lib.WorkerID, masterID lib.MasterID, config WorkerConfig) lib.WorkerImpl {
@@ -15,6 +13,6 @@ func RegisterFake(registry Registry) {
 	}, &fake.Config{})
 	registry.MustRegisterWorkerType(lib.FakeJobMaster, fakeMasterFactory)
 
-	fakeWorkerFactory := NewSimpleWorkerFactory(fake.NewDummyWorker, &FakeConfig{})
+	fakeWorkerFactory := NewSimpleWorkerFactory(fake.NewDummyWorker, &fake.WorkerConfig{})
 	registry.MustRegisterWorkerType(lib.FakeTask, fakeWorkerFactory)
 }

--- a/lib/registry/registry_test.go
+++ b/lib/registry/registry_test.go
@@ -12,16 +12,12 @@ import (
 
 var (
 	_                 WorkerFactory = (*SimpleWorkerFactory)(nil)
-	fakeWorkerFactory WorkerFactory = NewSimpleWorkerFactory(fake.NewDummyWorker, &dummyConfig{})
+	fakeWorkerFactory WorkerFactory = NewSimpleWorkerFactory(fake.NewDummyWorker, &fake.WorkerConfig{})
 )
 
 const (
 	fakeWorkerType = lib.WorkerType(100)
 )
-
-type dummyConfig struct {
-	Val int
-}
 
 func TestGlobalRegistry(t *testing.T) {
 	GlobalWorkerRegistry().MustRegisterWorkerType(fakeWorkerType, fakeWorkerFactory)
@@ -31,7 +27,7 @@ func TestGlobalRegistry(t *testing.T) {
 		fakeWorkerType,
 		"worker-1",
 		"master-1",
-		[]byte(`{"Val":0}`))
+		[]byte(`{"target-tick":10}`))
 	require.NoError(t, err)
 	require.IsType(t, &lib.DefaultBaseWorker{}, worker)
 	impl := worker.(*lib.DefaultBaseWorker).Impl

--- a/lib/status.go
+++ b/lib/status.go
@@ -98,6 +98,14 @@ func (s *StatusSender) setLastUnsentStatus(status *WorkerStatus) {
 	s.lastUnsentStatus = status
 }
 
+// SafeSendStatus persists status before sending it
+func (s *StatusSender) SafeSendStatus(ctx context.Context, status WorkerStatus) error {
+	if err := s.workerMetaClient.Store(ctx, s.workerID, &status); err != nil {
+		return err
+	}
+	return s.SendStatus(ctx, status)
+}
+
 // SendStatus is used by the business logic in a worker to notify its master
 // of a status change.
 // This function is non-blocking and if any error occurred during or after network IO,

--- a/lib/status_test.go
+++ b/lib/status_test.go
@@ -34,10 +34,10 @@ func TestStatusSender(t *testing.T) {
 	})
 
 	putMasterMeta(ctx, t, metaClient, &MasterMetaKVData{
-		ID:          masterName,
-		NodeID:      masterNodeName,
-		Epoch:       1,
-		Initialized: true,
+		ID:         masterName,
+		NodeID:     masterNodeName,
+		Epoch:      1,
+		StatusCode: MasterStatusInit,
 	})
 	err := masterClient.InitMasterInfoFromMeta(ctx)
 	require.NoError(t, err)

--- a/lib/worker_test.go
+++ b/lib/worker_test.go
@@ -38,10 +38,10 @@ func TestWorkerInitAndClose(t *testing.T) {
 	worker.clock = clock.NewMock()
 	worker.clock.(*clock.Mock).Set(time.Now())
 	putMasterMeta(ctx, t, worker.metaKVClient, &MasterMetaKVData{
-		ID:          masterName,
-		NodeID:      masterNodeName,
-		Epoch:       1,
-		Initialized: true,
+		ID:         masterName,
+		NodeID:     masterNodeName,
+		Epoch:      1,
+		StatusCode: MasterStatusInit,
 	})
 
 	worker.On("InitImpl", mock.Anything).Return(nil)
@@ -104,10 +104,10 @@ func TestWorkerHeartbeatPingPong(t *testing.T) {
 	worker.clock = clock.NewMock()
 	worker.clock.(*clock.Mock).Set(time.Now())
 	putMasterMeta(ctx, t, worker.metaKVClient, &MasterMetaKVData{
-		ID:          masterName,
-		NodeID:      masterNodeName,
-		Epoch:       1,
-		Initialized: true,
+		ID:         masterName,
+		NodeID:     masterNodeName,
+		Epoch:      1,
+		StatusCode: MasterStatusInit,
 	})
 
 	worker.On("InitImpl", mock.Anything).Return(nil)
@@ -160,10 +160,10 @@ func TestWorkerMasterFailover(t *testing.T) {
 	worker.clock = clock.NewMock()
 	worker.clock.(*clock.Mock).Set(time.Now())
 	putMasterMeta(ctx, t, worker.metaKVClient, &MasterMetaKVData{
-		ID:          masterName,
-		NodeID:      masterNodeName,
-		Epoch:       1,
-		Initialized: true,
+		ID:         masterName,
+		NodeID:     masterNodeName,
+		Epoch:      1,
+		StatusCode: MasterStatusInit,
 	})
 
 	worker.On("InitImpl", mock.Anything).Return(nil)
@@ -196,10 +196,10 @@ func TestWorkerMasterFailover(t *testing.T) {
 
 	worker.clock.(*clock.Mock).Add(time.Second * 1)
 	putMasterMeta(ctx, t, worker.metaKVClient, &MasterMetaKVData{
-		ID:          masterName,
-		NodeID:      executorNodeID3,
-		Epoch:       2,
-		Initialized: true,
+		ID:         masterName,
+		NodeID:     executorNodeID3,
+		Epoch:      2,
+		StatusCode: MasterStatusInit,
 	})
 
 	worker.On("OnMasterFailover", mock.Anything).Return(nil)
@@ -222,10 +222,10 @@ func TestWorkerStatus(t *testing.T) {
 	worker.clock = clock.NewMock()
 	worker.clock.(*clock.Mock).Set(time.Now())
 	putMasterMeta(ctx, t, worker.metaKVClient, &MasterMetaKVData{
-		ID:          masterName,
-		NodeID:      masterNodeName,
-		Epoch:       1,
-		Initialized: true,
+		ID:         masterName,
+		NodeID:     masterNodeName,
+		Epoch:      1,
+		StatusCode: MasterStatusInit,
 	})
 
 	worker.On("InitImpl", mock.Anything).Return(nil)
@@ -286,10 +286,10 @@ func TestWorkerSuicide(t *testing.T) {
 	worker.clock = clock.NewMock()
 	worker.clock.(*clock.Mock).Set(time.Now())
 	putMasterMeta(ctx, t, worker.metaKVClient, &MasterMetaKVData{
-		ID:          masterName,
-		NodeID:      masterNodeName,
-		Epoch:       1,
-		Initialized: true,
+		ID:         masterName,
+		NodeID:     masterNodeName,
+		Epoch:      1,
+		StatusCode: MasterStatusInit,
 	})
 
 	worker.On("InitImpl", mock.Anything).Return(nil)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -59,12 +59,13 @@ var (
 
 	ErrWorkerTypeNotFound         = errors.Normalize("worker type is not found: type %d", errors.RFCCodeText("DFLOW:ErrWorkerTypeNotFound"))
 	ErrWorkerNotFound             = errors.Normalize("worker is not found: worker ID %s", errors.RFCCodeText("DFLOW:ErrWorkerNotFound"))
-	ErrWorkerOffline              = errors.Normalize("worker is offline: workerID %s", errors.RFCCodeText("DFLOW:ErrWorkerOffline"))
+	ErrWorkerOffline              = errors.Normalize("worker is offline: workerID: %s, error message: %s", errors.RFCCodeText("DFLOW:ErrWorkerOffline"))
 	ErrWorkerTimedOut             = errors.Normalize("worker heartbeat timed out: workerID %s", errors.RFCCodeText("DFLOW:ErrWorkerTimedOut"))
 	ErrWorkerSuicide              = errors.Normalize("worker has committed suicide due to master(%s) having timed out", errors.RFCCodeText("DFLOW:ErrWorkerSuicide"))
 	ErrWorkerNoMeta               = errors.Normalize("worker metadata does not exist", errors.RFCCodeText("DFLOW:ErrWorkerNoMeta"))
 	ErrWorkerUpdateStatusTryAgain = errors.Normalize("worker should try again in updating the status", errors.RFCCodeText("DFLOW:ErrWorkerUpdateStatusTryAgain"))
 	ErrInvalidJobType             = errors.Normalize("invalid job type: %s", errors.RFCCodeText("DFLOW:ErrInvalidJobType"))
+	ErrWorkerFinish               = errors.Normalize("worker finished and exited", errors.RFCCodeText("DFLOW:ErrWorkerFinish"))
 
 	// master etcd related errors
 	ErrMasterEtcdCreateSessionFail    = errors.Normalize("failed to create Etcd session", errors.RFCCodeText("DFLOW:ErrMasterEtcdCreateSessionFail"))

--- a/sample/config/fake_job.json
+++ b/sample/config/fake_job.json
@@ -1,4 +1,5 @@
 {
     "job-name": "test-fake-job-1",
-    "worker-count": 20
+    "worker-count": 20,
+    "target-tick": 300
 }

--- a/servermaster/job_fsm.go
+++ b/servermaster/job_fsm.go
@@ -196,7 +196,7 @@ func (fsm *JobFsm) JobOnline(worker lib.WorkerHandle) error {
 	return nil
 }
 
-func (fsm *JobFsm) JobOffline(worker lib.WorkerHandle) {
+func (fsm *JobFsm) JobOffline(worker lib.WorkerHandle, needFailover bool) {
 	fsm.jobsMu.Lock()
 	defer fsm.jobsMu.Unlock()
 
@@ -205,7 +205,9 @@ func (fsm *JobFsm) JobOffline(worker lib.WorkerHandle) {
 		log.L().Warn("non-online worker offline, ignore it", zap.String("id", worker.ID()))
 		return
 	}
-	fsm.pendingJobs[worker.ID()] = job.MasterMetaKVData
+	if needFailover {
+		fsm.pendingJobs[worker.ID()] = job.MasterMetaKVData
+	}
 	delete(fsm.onlineJobs, worker.ID())
 }
 

--- a/servermaster/job_fsm_test.go
+++ b/servermaster/job_fsm_test.go
@@ -31,7 +31,7 @@ func TestJobFsmStateTrans(t *testing.T) {
 	require.Equal(t, 1, fsm.JobCount(pb.QueryJobResponse_online))
 
 	// OnWorkerOffline, Online -> Pending
-	fsm.JobOffline(worker)
+	fsm.JobOffline(worker, true /* needFailover */)
 	require.Equal(t, 0, fsm.JobCount(pb.QueryJobResponse_online))
 	require.Equal(t, 1, fsm.JobCount(pb.QueryJobResponse_pending))
 


### PR DESCRIPTION
This PR supports worker to exit normally when its worker is done. The changes include
- Remove `Initialized` from `MasterMetaKVData` and add `StatusCode`, which combines the initialization semantic and job master working status.
- Add an `Exit` API in both `BaseJobMaster` and `BaseWorker`, when job master or worker (in user logic code) wants to exit and marks job as finished, it can call the `Exit` function directly.
- After `Exit` is called, base worker will update worker status to finished, and job master will mark master meta to finished to.
- When job manager failovers, it will skip all finished job masters.