### PR TITLE
cvsJob: support normal exit in cvs job

### DIFF
--- a/jobmaster/cvsJob/cvsJobMaster.go
+++ b/jobmaster/cvsJob/cvsJobMaster.go
@@ -165,6 +165,8 @@ func (jm *JobMaster) OnWorkerOffline(worker lib.WorkerHandle, reason error) erro
 	if !exist {
 		log.L().Panic("bad worker found", zap.Any("message", worker.ID()))
 	}
+	// Force to set worker handle, in case of worker finishes before OnWorkerOnline
+	// is fired and worker handle is missing
 	syncInfo.handle = worker
 	if derrors.ErrWorkerFinish.Equal(reason) {
 		log.L().Info("worker finished", zap.String("worker-id", worker.ID()), zap.Any("status", worker.Status()))

--- a/jobmaster/cvsJob/cvsJobMaster.go
+++ b/jobmaster/cvsJob/cvsJobMaster.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/pingcap/tiflow/dm/pkg/log"
 	"go.uber.org/zap"
+	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 
 	cvsTask "github.com/hanfei1991/microcosm/executor/cvsTask"
@@ -16,7 +18,7 @@ import (
 	"github.com/hanfei1991/microcosm/model"
 	"github.com/hanfei1991/microcosm/pb"
 	dcontext "github.com/hanfei1991/microcosm/pkg/context"
-	"github.com/hanfei1991/microcosm/pkg/errors"
+	derrors "github.com/hanfei1991/microcosm/pkg/errors"
 	"github.com/hanfei1991/microcosm/pkg/p2p"
 )
 
@@ -43,12 +45,13 @@ func (e *errorInfo) Error() string {
 
 type JobMaster struct {
 	lib.BaseJobMaster
-	syncInfo      *Config
-	syncFilesInfo map[lib.WorkerID]*workerInfo
-	counter       int64
-	workerID      lib.WorkerID
-	status        lib.WorkerStatusCode
-	filesNum      int
+	syncInfo          *Config
+	syncFilesInfo     map[lib.WorkerID]*workerInfo
+	counter           int64
+	workerID          lib.WorkerID
+	status            lib.WorkerStatusCode
+	filesNum          int
+	statusRateLimiter *rate.Limiter
 }
 
 func RegisterWorker() {
@@ -64,6 +67,7 @@ func NewCVSJobMaster(ctx *dcontext.Context, workerID lib.WorkerID, masterID lib.
 	jm.workerID = workerID
 	jm.syncInfo = conf.(*Config)
 	jm.syncFilesInfo = make(map[lib.WorkerID]*workerInfo)
+	jm.statusRateLimiter = rate.NewLimiter(rate.Every(time.Second*2), 1)
 	log.L().Info("new cvs jobmaster ", zap.Any("id :", jm.workerID))
 	return jm
 }
@@ -125,14 +129,12 @@ func (jm *JobMaster) Tick(ctx context.Context) error {
 			log.L().Info("worker status abnormal", zap.Any("status", status))
 		}
 	}
-	log.L().Info("cvs job master status", zap.Any("id", jm.workerID), zap.Int64("counter", jm.counter), zap.Any("status", jm.status))
-	if filesNum == jm.filesNum && jm.status != lib.WorkerStatusFinished {
-		jm.status = lib.WorkerStatusFinished
-		err := jm.BaseJobMaster.UpdateJobStatus(ctx, jm.Status())
-		if errors.ErrWorkerUpdateStatusTryAgain.Equal(err) {
-			log.L().Warn("update status try again later", zap.String("error", err.Error()))
-			return nil
-		}
+	if jm.statusRateLimiter.Allow() {
+		log.L().Info("cvs job master status", zap.Any("id", jm.workerID), zap.Int64("counter", jm.counter), zap.Any("status", jm.status))
+	}
+	if filesNum == jm.filesNum {
+		log.L().Info("cvs job master finished")
+		return jm.BaseJobMaster.Exit(ctx, jm.Status(), nil)
 	}
 	return nil
 }
@@ -161,7 +163,12 @@ func (jm *JobMaster) OnWorkerOffline(worker lib.WorkerHandle, reason error) erro
 	syncInfo, exist := jm.syncFilesInfo[worker.ID()]
 	log.L().Info("on worker offline ", zap.Any(" worker :", worker.ID()))
 	if !exist {
-		log.L().Info("bad worker found", zap.Any("message", worker.ID()))
+		log.L().Panic("bad worker found", zap.Any("message", worker.ID()))
+	}
+	syncInfo.handle = worker
+	if derrors.ErrWorkerFinish.Equal(reason) {
+		log.L().Info("worker finished", zap.String("worker-id", worker.ID()), zap.Any("status", worker.Status()))
+		return nil
 	}
 	var err error
 	dstDir := jm.syncInfo.DstDir + "/" + syncInfo.file

--- a/lib/worker_manager.go
+++ b/lib/worker_manager.go
@@ -255,6 +255,7 @@ func (m *workerManagerImpl) Tick(
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	pendingWorkers := make([]*WorkerInfo, 0)
 	// TODO gracefully handle all errors that could occur in this function
 	// respond to worker heartbeats
 	for workerID, workerInfo := range m.workerInfos {
@@ -264,6 +265,9 @@ func (m *workerManagerImpl) Tick(
 		if workerInfo.justOnlined && workerInfo.hasPendingHeartbeat && workerInfo.statusInitialized.Load() {
 			workerInfo.justOnlined = false
 			onlinedWorkers = append(onlinedWorkers, workerInfo)
+		}
+		if workerInfo.justOnlined {
+			pendingWorkers = append(pendingWorkers, workerInfo)
 		}
 
 		if workerInfo.hasTimedOut(m.clock, &m.timeoutConfig) {

--- a/lib/worker_manager.go
+++ b/lib/worker_manager.go
@@ -255,7 +255,6 @@ func (m *workerManagerImpl) Tick(
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	pendingWorkers := make([]*WorkerInfo, 0)
 	// TODO gracefully handle all errors that could occur in this function
 	// respond to worker heartbeats
 	for workerID, workerInfo := range m.workerInfos {
@@ -265,9 +264,6 @@ func (m *workerManagerImpl) Tick(
 		if workerInfo.justOnlined && workerInfo.hasPendingHeartbeat && workerInfo.statusInitialized.Load() {
 			workerInfo.justOnlined = false
 			onlinedWorkers = append(onlinedWorkers, workerInfo)
-		}
-		if workerInfo.justOnlined {
-			pendingWorkers = append(pendingWorkers, workerInfo)
 		}
 
 		if workerInfo.hasTimedOut(m.clock, &m.timeoutConfig) {

--- a/servermaster/job_fsm.go
+++ b/servermaster/job_fsm.go
@@ -155,10 +155,7 @@ func (fsm *JobFsm) QueryJob(jobID lib.MasterID) *pb.QueryJobResponse {
 	if resp := checkWaitAckJob(); resp != nil {
 		return resp
 	}
-	if resp := checkOnlineJob(); resp != nil {
-		return resp
-	}
-	return nil
+	return checkOnlineJob()
 }
 
 func (fsm *JobFsm) JobDispatched(job *lib.MasterMetaKVData) {

--- a/servermaster/job_fsm.go
+++ b/servermaster/job_fsm.go
@@ -73,29 +73,52 @@ func NewJobFsm() *JobFsm {
 }
 
 func (fsm *JobFsm) QueryJob(jobID lib.MasterID) *pb.QueryJobResponse {
-	fsm.jobsMu.Lock()
-	defer fsm.jobsMu.Unlock()
-	resp := &pb.QueryJobResponse{}
-	meta, ok := fsm.pendingJobs[jobID]
-	if ok {
-		resp.Tp = int64(meta.Tp)
-		resp.Config = meta.Config
-		resp.Status = pb.QueryJobResponse_pending
+	checkPendingJob := func() *pb.QueryJobResponse {
+		fsm.jobsMu.Lock()
+		defer fsm.jobsMu.Unlock()
+
+		meta, ok := fsm.pendingJobs[jobID]
+		if !ok {
+			return nil
+		}
+		resp := &pb.QueryJobResponse{
+			Tp:     int64(meta.Tp),
+			Config: meta.Config,
+			Status: pb.QueryJobResponse_pending,
+		}
 		return resp
 	}
-	job, ok := fsm.waitAckJobs[jobID]
-	if ok {
-		meta = job.MasterMetaKVData
-		resp.Tp = int64(meta.Tp)
-		resp.Config = meta.Config
-		resp.Status = pb.QueryJobResponse_dispatched
+
+	checkWaitAckJob := func() *pb.QueryJobResponse {
+		fsm.jobsMu.Lock()
+		defer fsm.jobsMu.Unlock()
+
+		job, ok := fsm.waitAckJobs[jobID]
+		if !ok {
+			return nil
+		}
+		meta := job.MasterMetaKVData
+		resp := &pb.QueryJobResponse{
+			Tp:     int64(meta.Tp),
+			Config: meta.Config,
+			Status: pb.QueryJobResponse_dispatched,
+		}
 		return resp
 	}
-	job, ok = fsm.onlineJobs[jobID]
-	resp.Status = pb.QueryJobResponse_online
-	if ok {
-		resp.Tp = int64(job.Tp)
-		resp.Config = job.Config
+
+	checkOnlineJob := func() *pb.QueryJobResponse {
+		fsm.jobsMu.Lock()
+		defer fsm.jobsMu.Unlock()
+
+		job, ok := fsm.onlineJobs[jobID]
+		if !ok {
+			return nil
+		}
+		resp := &pb.QueryJobResponse{
+			Tp:     int64(job.Tp),
+			Config: job.Config,
+			Status: pb.QueryJobResponse_online,
+		}
 		jobInfo, err := job.ToPB()
 		// TODO (zixiong) ToPB should handle the tombstone situation gracefully.
 		if err != nil {
@@ -123,12 +146,19 @@ func (fsm *JobFsm) QueryJob(jobID lib.MasterID) *pb.QueryJobResponse {
 			// TODO think about
 			log.L().Panic("Unexpected Job Info")
 		}
-	} else {
-		resp.Err = &pb.Error{
-			Code: pb.ErrorCode_UnKnownJob,
-		}
+		return nil
 	}
-	return resp
+
+	if resp := checkPendingJob(); resp != nil {
+		return resp
+	}
+	if resp := checkWaitAckJob(); resp != nil {
+		return resp
+	}
+	if resp := checkOnlineJob(); resp != nil {
+		return resp
+	}
+	return nil
 }
 
 func (fsm *JobFsm) JobDispatched(job *lib.MasterMetaKVData) {


### PR DESCRIPTION
This PR supports cvs job exits when it finishes.

- In both cvs task and cvs job master, call `Exit` when it is finished.
- Support querying finished job in job manager
- Fix several bugs in cvs job, including data race for counter, missing handler for worker if a task finishes before `OnWorkerOnline` is fired.