### PR TITLE
servermaster: close job manager after leader exits

### DIFF
--- a/servermaster/server.go
+++ b/servermaster/server.go
@@ -611,6 +611,10 @@ func (s *Server) runLeaderService(ctx context.Context) (err error) {
 	defer func() {
 		s.leader.Store(&Member{})
 		s.resign()
+		err := s.jobManager.Close(ctx)
+		if err != nil {
+			log.L().Warn("job manager close with error", zap.Error(err))
+		}
 	}()
 
 	metricTicker := time.NewTicker(defaultMetricInterval)

--- a/servermaster/server_test.go
+++ b/servermaster/server_test.go
@@ -226,6 +226,14 @@ func TestRunLeaderService(t *testing.T) {
 	err = s.runLeaderService(ctx1)
 	require.EqualError(t, err, context.DeadlineExceeded.Error())
 
+	// runLeaderService exits, try to campaign to be leader and run leader servcie again
+	err = s.campaign(ctx, time.Second)
+	require.Nil(t, err)
+	ctx2, cancel2 := context.WithTimeout(ctx, time.Second)
+	defer cancel2()
+	err = s.runLeaderService(ctx2)
+	require.EqualError(t, err, context.DeadlineExceeded.Error())
+
 	cancel()
 	wg.Wait()
 }


### PR DESCRIPTION
Fix #224

- `jobManager` is not closed after leader loop exits, just close it.
- The root cause of panic: If we don't close job manager, the registered message handler is not cleaned up and remained in `messageServer`, `messageServer` is a singleton in the server master node. The next time this server node campaigns to be leader and register message handler again, the panic is raised.