### PR TITLE
servermaster: remove forward api log

### DIFF
--- a/servermaster/server.go
+++ b/servermaster/server.go
@@ -699,15 +699,13 @@ func (s *Server) rpcForwardIfNeeded(ctx context.Context, req interface{}, respPo
 		return false
 	}
 	if needForward {
-		leader, exist := s.checkLeader()
+		_, exist := s.checkLeader()
 		if !exist {
 			respType := reflect.ValueOf(respPointer).Elem().Type()
 			reflect.ValueOf(respPointer).Elem().Set(reflect.Zero(respType))
 			*errPointer = errors.ErrMasterRPCNotForward.GenWithStackByArgs()
 			return true
 		}
-		log.L().Info("will forward rpc request", zap.String("from", s.name()),
-			zap.String("to", leader.Name), zap.String("request", methodName))
 
 		params := []reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(req)}
 		s.leaderClient.RLock()

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -140,7 +140,7 @@ func testSubmitTest(t *testing.T, cfg *cvs.Config, config *Config) {
 		if queryResp.Status == pb.QueryJobResponse_finished {
 			break
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(time.Second)
 	}
 	fmt.Printf("job id %s checking\n", resp.JobIdStr)
 	// check files


### PR DESCRIPTION
Find this log bumps too much in test, mainly heartbeat rpc from executor.