### PR TITLE
master: register message handler after workerManager is initialized

### DIFF
--- a/lib/master.go
+++ b/lib/master.go
@@ -213,10 +213,6 @@ func (m *DefaultBaseMaster) Init(ctx context.Context) error {
 }
 
 func (m *DefaultBaseMaster) doInit(ctx context.Context) (isFirstStartUp bool, err error) {
-	if err := m.registerMessageHandlers(ctx); err != nil {
-		return false, errors.Trace(err)
-	}
-
 	isInit, epoch, err := m.refreshMetadata(ctx)
 	if err != nil {
 		return false, errors.Trace(err)
@@ -237,6 +233,10 @@ func (m *DefaultBaseMaster) doInit(ctx context.Context) (isFirstStartUp bool, er
 		!isInit,
 		epoch,
 		&m.timeoutConfig)
+
+	if err := m.registerMessageHandlers(ctx); err != nil {
+		return false, errors.Trace(err)
+	}
 
 	m.startBackgroundTasks()
 	return isInit, nil


### PR DESCRIPTION
Fix the following panic.
The root cause is when a job master recovers, the worker could keep sending heartbeat, which is as expected. We must prepare necessary deps before registering message handler, otherwise the job master receives heartbeat and processes without enough deps(workerManager) and leads to panic.

Affected version: https://github.com/hanfei1991/microcosm/commit/ee7f5ffb17ddfbb7e7bd5b686b2506c3d87cac0d

https://github.com/hanfei1991/microcosm/blob/ee7f5ffb17ddfbb7e7bd5b686b2506c3d87cac0d/lib/master.go#L252

```
[2022/03/17 14:58:21.861 +08:00] [INFO] [server.go:189] ["dispatch task"] [req="task_type_id:2 task_config:\"{\\n   \\\"srcHost\\\":\\\"127.0.0.1:1234\\\",\\n   \\\"srcDir\\\":\\\"/home/apple/work/code/microcosm/bin/source\\\",\\n   \\\"dstHost\\\":\\\"127.0.0.1:1234\\\",\\n   \\\"dstDir\\\":\\\"/home/apple/work/code/microcosm/bin/target\\\"\\n}\\n\" master_id:\"dataflow-engine-job-manager\" worker_id:\"73cfd666-a62e-43a7-a892-ef6c7f127dac\" "]
[2022/03/17 14:58:21.861 +08:00] [INFO] [cvsJobMaster.go:70] ["new cvs jobmaster "] ["id :"=73cfd666-a62e-43a7-a892-ef6c7f127dac]
panic: runtime error: invalid memory address or nil pointer dereference          
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x3912685]         
                                                                                 
goroutine 232 [running]:                                                         
github.com/hanfei1991/microcosm/lib.(*DefaultBaseMaster).registerMessageHandlers.func1({0xc00162c0c0, 0x61}, {0x3f03ca0, 0xc00078b6e0})
    /home/apple/work/code/microcosm/lib/master.go:252 +0x45                      
github.com/pingcap/tiflow/pkg/p2p.(*MessageServer).AddHandler.func1({0xc00047a840, 0xc00167cd80}, {0x41e1ca0, 0xc0022ff4b0})
    /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/github.com/pingcap/tiflow@v0.0.0-20220308162507-e342c02e789c/pkg/p2p/server.go:430 +0x222
github.com/pingcap/tiflow/pkg/workerpool.(*defaultEventHandle).AddEvent.func2({0xc00161de98, 0xc00161dd68})
    /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/github.com/pingcap/tiflow@v0.0.0-20220308162507-e342c02e789c/pkg/workerpool/pool_impl.go:140 +0x30
github.com/pingcap/tiflow/pkg/workerpool.(*worker).run(0xc0002db4d0, {0x4cb0828, 0xc0000a3640})
    /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/github.com/pingcap/tiflow@v0.0.0-20220308162507-e342c02e789c/pkg/workerpool/pool_impl.go:348 +0x3e3
github.com/pingcap/tiflow/pkg/workerpool.(*defaultPoolImpl).Run.func1()          
    /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/github.com/pingcap/tiflow@v0.0.0-20220308162507-e342c02e789c/pkg/workerpool/pool_impl.go:67 +0x28
golang.org/x/sync/errgroup.(*Group).Go.func1()                                   
    /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x67
created by golang.org/x/sync/errgroup.(*Group).Go                                
    /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x92
```

```
[2022/03/17 14:58:21.858 +08:00] [WARN] [worker_manager.go:561] ["Worker timed out"] [duration=15.421206519s] [id=73cfd666-a62e-43a7-a892-ef6c7f127dac]
[2022/03/17 14:58:21.858 +08:00] [INFO] [master.go:397] ["worker is offline"] [master-id=dataflow-engine-job-manager] [worker-info="{\"ID\":\"73cfd666-a62e-43a7-a892-ef6c7f127dac\",\"NodeID\":\"bdc39be1-c586-42df-a57b-ed2d898aa3c2\"}"]
[2022/03/17 14:58:21.858 +08:00] [INFO] [jobmanager.go:248] ["on worker offline"] [id=73cfd666-a62e-43a7-a892-ef6c7f127dac] [reason="[DFLOW:ErrWorkerOffline]worker is offline: workerID: 73cfd666-a62e-43a7-a892-ef6c7f127dac, error message: %!s(MISSING)"[2022/03/17 14:58:21.859 +08:00] [INFO] [master.go:513] [CreateWorker] [worker-type=2] [worker-config="{\"id\":\"73cfd666-a62e-43a7-a892-ef6c7f127dac\",\"addr\":\"\",\"node-id\":\"\",\"epoch\":2580,\"status\":1,\"type\":2,\"config\":\"ewogICAic3JjSG9zd[2022/03/17 14:58:21.860 +08:00] [INFO] [job_fsm.go:184] ["job master recovered"] [job="{\"id\":\"73cfd666-a62e-43a7-a892-ef6c7f127dac\",\"addr\":\"\",\"node-id\":\"\",\"epoch\":2580,\"status\":1,\"type\":2,\"config\":\"ewogICAic3JjSG9zdCI6IjEyNy4wLjAu[2022/03/17 14:58:21.860 +08:00] [INFO] [client_manager.go:61] ["client manager adds executor"] [id=824db235-c387-436e-a6f8-09c6176b7962] [addr=127.0.0.1:10241]
[2022/03/17 14:58:21.862 +08:00] [INFO] [master.go:590] ["Worker dispatched"] [master-id=dataflow-engine-job-manager] [response="error_code:OK worker_id:\"73cfd666-a62e-43a7-a892-ef6c7f127dac\" "]
```