### PR TITLE
lib/worker: create a fake resource broker temporarily

### DIFF
--- a/executor/server.go
+++ b/executor/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hanfei1991/microcosm/pkg/deps"
 	"github.com/hanfei1991/microcosm/pkg/errors"
 	"github.com/hanfei1991/microcosm/pkg/externalresource"
+	"github.com/hanfei1991/microcosm/pkg/externalresource/broker"
 	"github.com/hanfei1991/microcosm/pkg/metadata"
 	"github.com/hanfei1991/microcosm/pkg/p2p"
 	"github.com/hanfei1991/microcosm/pkg/serverutils"
@@ -177,6 +178,14 @@ func (s *Server) buildDeps(wid lib.WorkerID) (*deps.Deps, error) {
 	}
 	err = deps.Provide(func() externalresource.Proxy {
 		return proxy
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = deps.Provide(func() broker.Broker {
+		// TODO: use correct broker.Broker
+		return nil
 	})
 	if err != nil {
 		return nil, err

--- a/lib/worker.go
+++ b/lib/worker.go
@@ -107,7 +107,7 @@ type workerParams struct {
 	MessageHandlerManager p2p.MessageHandlerManager
 	MessageSender         p2p.MessageSender
 	MetaKVClient          metadata.MetaKV
-	ResourceBroker        broker.Broker
+	// ResourceBroker        broker.Broker
 }
 
 func NewBaseWorker(
@@ -127,7 +127,7 @@ func NewBaseWorker(
 		messageHandlerManager: params.MessageHandlerManager,
 		messageSender:         params.MessageSender,
 		metaKVClient:          params.MetaKVClient,
-		resourceBroker:        params.ResourceBroker,
+		// resourceBroker:        params.ResourceBroker,
 
 		masterID:      masterID,
 		id:            workerID,

--- a/lib/worker.go
+++ b/lib/worker.go
@@ -107,7 +107,7 @@ type workerParams struct {
 	MessageHandlerManager p2p.MessageHandlerManager
 	MessageSender         p2p.MessageSender
 	MetaKVClient          metadata.MetaKV
-	// ResourceBroker        broker.Broker
+	ResourceBroker        broker.Broker
 }
 
 func NewBaseWorker(
@@ -127,7 +127,7 @@ func NewBaseWorker(
 		messageHandlerManager: params.MessageHandlerManager,
 		messageSender:         params.MessageSender,
 		metaKVClient:          params.MetaKVClient,
-		// resourceBroker:        params.ResourceBroker,
+		resourceBroker:        params.ResourceBroker,
 
 		masterID:      masterID,
 		id:            workerID,


### PR DESCRIPTION
Since resource broker is not used now, create a fake resource broker temporarily.

Fix panic
```go
[2022/03/21 15:10:22.542 +08:00] [PANIC] [worker.go:123] ["Failed to fill dependencies for BaseWorker"] [error="missing dependencies for function \"reflect\".makeFuncStub (/home/apple/.gvm/gos/go1.17.7/src/reflect/asm_amd64.s:30): missing type: broker.panic: Failed to fill dependencies for BaseWorker                                
                                                                                 
goroutine 264 [running]:                                                         
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc0001709c0, {0xc000d98400, 0x1, 0x1})
    /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/go.uber.org/zap@v1.20.0/zapcore/entry.go:232 +0x446
go.uber.org/zap.(*Logger).Panic(0xc000e4c840, {0x462a243, 0xc000989560}, {0xc000d98400, 0x1, 0x1})
    /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/go.uber.org/zap@v1.20.0/logger.go:230 +0x59
github.com/hanfei1991/microcosm/lib.NewBaseWorker(0xc000272820, {0x4cd5c48, 0xc000b25df0}, {0xc000a4da10, 0x24}, {0xc000a05be0, 0x1b})
    /home/apple/work/code/microcosm/lib/worker.go:123 +0x1eb                     
github.com/hanfei1991/microcosm/lib.NewBaseJobMaster(0x44bf4c0, {0x7f2d7449ed80, 0xc000679b80}, {0xc000a05be0, 0x1b}, {0xc000a4da10, 0x24})
    /home/apple/work/code/microcosm/lib/base_jobmaster.go:87 +0x12c              
github.com/hanfei1991/microcosm/lib/registry.(*registryImpl).CreateWorker(0xc000395680, 0x1, 0x1, {0xc000a4da10, 0x24}, {0xc000a05be0, 0x1b}, {0xc000c8e840, 0x55, 0x60})
    /home/apple/work/code/microcosm/lib/registry/registry.go:92 +0x1b4           
github.com/hanfei1991/microcosm/executor.(*Server).DispatchTask(0xc000170900, {0xc000395380, 0x15cb286}, 0xc000395380)
    /home/apple/work/code/microcosm/executor/server.go:220 +0x845                
github.com/hanfei1991/microcosm/pb._Executor_DispatchTask_Handler({0x4441180, 0xc000170900}, {0x4cc1770, 0xc000cba270}, 0xc000988cc0, 0x0)
    /home/apple/work/code/microcosm/pb/executor.pb.go:741 +0x170                 
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000afb180, {0x4d04878, 0xc0006736c0}, 0xc000cb0120, 0xc000eb76b0, 0x69d04a8, 0x0)
    /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:1282 +0xccf
google.golang.org/grpc.(*Server).handleStream(0xc000afb180, {0x4d04878, 0xc0006736c0}, 0xc000cb0120, 0x0)
    /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:1616 +0xa2a
google.golang.org/grpc.(*Server).serveStreams.func1.2()                          
    /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:921 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1                   
    /home/apple/.gvm/pkgsets/go1.17.7/global/pkg/mod/google.golang.org/grpc@v1.43.0/server.go:919 +0x294
```