### PR TITLE
lib/worker: fix data race when updating worker status synchronously

### DIFF
--- a/jobmaster/cvsJob/cvsJobMaster.go
+++ b/jobmaster/cvsJob/cvsJobMaster.go
@@ -151,6 +151,7 @@ func (jm *JobMaster) Tick(ctx context.Context) error {
 		log.L().Info("cvs job master status", zap.Any("id", jm.workerID), zap.Int64("counter", jm.counter), zap.Any("status", jm.getStatusCode()))
 	}
 	if jm.getStatusCode() == lib.WorkerStatusStopped {
+		jm.setStatusCode(lib.WorkerStatusStopped)
 		log.L().Info("cvs job master stopped")
 		return jm.BaseJobMaster.Exit(ctx, jm.Status(), nil)
 	}

--- a/jobmaster/cvsJob/cvsJobMaster.go
+++ b/jobmaster/cvsJob/cvsJobMaster.go
@@ -151,7 +151,6 @@ func (jm *JobMaster) Tick(ctx context.Context) error {
 		log.L().Info("cvs job master status", zap.Any("id", jm.workerID), zap.Int64("counter", jm.counter), zap.Any("status", jm.getStatusCode()))
 	}
 	if jm.getStatusCode() == lib.WorkerStatusStopped {
-		jm.setStatusCode(lib.WorkerStatusStopped)
 		log.L().Info("cvs job master stopped")
 		return jm.BaseJobMaster.Exit(ctx, jm.Status(), nil)
 	}

--- a/lib/fake/fake_master.go
+++ b/lib/fake/fake_master.go
@@ -171,10 +171,12 @@ func (m *Master) Tick(ctx context.Context) error {
 
 	if m.getStatusCode() == lib.WorkerStatusStopped {
 		log.L().Info("FakeMaster: received pause command, stop now")
+		m.setStatusCode(lib.WorkerStatusStopped)
 		return m.Exit(ctx, m.Status(), nil)
 	}
 	if len(m.finishedSet) == m.config.WorkerCount {
 		log.L().Info("FakeMaster: all worker finished, job master exits now")
+		m.setStatusCode(lib.WorkerStatusFinished)
 		return m.Exit(ctx, m.Status(), nil)
 	}
 

--- a/lib/fake/fake_worker.go
+++ b/lib/fake/fake_worker.go
@@ -92,10 +92,12 @@ func (d *dummyWorker) Tick(ctx context.Context) error {
 	}
 
 	if d.getStatusCode() == lib.WorkerStatusStopped {
+		d.setStatusCode(lib.WorkerStatusStopped)
 		return d.Exit(ctx, d.Status(), nil)
 	}
 
 	if d.status.Tick >= d.config.TargetTick {
+		d.setStatusCode(lib.WorkerStatusFinished)
 		return d.Exit(ctx, d.Status(), nil)
 	}
 

--- a/lib/status.go
+++ b/lib/status.go
@@ -120,12 +120,12 @@ func (s *StatusSender) SafeSendStatus(ctx context.Context, status WorkerStatus) 
 
 // AsyncSendStatus wraps sendStatusWrapper with asyncPersist=true
 func (s *StatusSender) AsyncSendStatus(ctx context.Context, status WorkerStatus) error {
-	return s.sendStatusWrapper(ctx, status, true /* asyncPersist */)
+	return s.sendStatusWrapper(ctx, status, true)
 }
 
 // SyncSendStatus wraps sendStatusWrapper with asyncPersist=false
 func (s *StatusSender) SyncSendStatus(ctx context.Context, status WorkerStatus) error {
-	return s.sendStatusWrapper(ctx, status, false /* asyncPersist */)
+	return s.sendStatusWrapper(ctx, status, false)
 }
 
 // sendStatusWrapper is used by the business logic in a worker to notify its master

--- a/lib/status_test.go
+++ b/lib/status_test.go
@@ -54,7 +54,7 @@ func TestStatusSender(t *testing.T) {
 	err = sender.Tick(ctx)
 	require.NoError(t, err)
 
-	err = sender.SendStatus(ctx, WorkerStatus{
+	err = sender.AsyncSendStatus(ctx, WorkerStatus{
 		Code:         WorkerStatusNormal,
 		ErrorMessage: "test message",
 		ExtBytes:     fastMarshalDummyStatus(t, 5),
@@ -73,7 +73,7 @@ func TestStatusSender(t *testing.T) {
 	// simulate an RPC congestion
 	msgSender.SetBlocked(true)
 
-	err = sender.SendStatus(ctx, WorkerStatus{
+	err = sender.AsyncSendStatus(ctx, WorkerStatus{
 		Code:         WorkerStatusNormal,
 		ErrorMessage: "test message1",
 		ExtBytes:     fastMarshalDummyStatus(t, 5),
@@ -233,4 +233,89 @@ func TestStatusReceiver(t *testing.T) {
 
 	cancel()
 	wg.Wait()
+}
+
+func TestStatusSenderSafeSend(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	pool := workerpool.NewDefaultAsyncPool(1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = pool.Run(ctx)
+	}()
+
+	msgSender := p2p.NewMockMessageSender()
+	metaClient := metadata.NewMetaMock()
+
+	masterClient := newMasterClient(masterName, workerID1, msgSender, metaClient, clock.MonoNow(), func() error {
+		return nil
+	})
+
+	putMasterMeta(ctx, t, metaClient, &MasterMetaKVData{
+		ID:         masterName,
+		NodeID:     masterNodeName,
+		Epoch:      1,
+		StatusCode: MasterStatusInit,
+	})
+	err := masterClient.InitMasterInfoFromMeta(ctx)
+	require.NoError(t, err)
+
+	workerMetaClient := NewWorkerMetadataClient(masterName, metaClient)
+	sender := NewStatusSender(
+		workerID1,
+		masterClient,
+		workerMetaClient,
+		msgSender,
+		pool,
+	)
+
+	err = sender.Tick(ctx)
+	require.NoError(t, err)
+
+	// simulate an RPC congestion
+	msgSender.SetBlocked(true)
+	err = sender.AsyncSendStatus(ctx, WorkerStatus{
+		Code:         WorkerStatusNormal,
+		ErrorMessage: "test message1",
+		ExtBytes:     fastMarshalDummyStatus(t, 5),
+	})
+	require.NoError(t, err)
+
+	ctx1, cancel1 := context.WithTimeout(ctx, time.Millisecond*100)
+	defer cancel1()
+	// SafeSendStatus would block if there exists pending message
+	err = sender.SafeSendStatus(ctx1, WorkerStatus{Code: WorkerStatusFinished})
+	require.Error(t, err, context.Canceled)
+
+	// Call tick to send the pending message
+	msgSender.SetBlocked(false)
+	err = sender.Tick(ctx)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		msg, ok := msgSender.TryPop(masterNodeName, WorkerStatusUpdatedTopic(masterName))
+		if !ok {
+			return false
+		}
+		require.Equal(t, &WorkerStatusUpdatedMessage{FromWorkerID: workerID1, Epoch: 1}, msg)
+		return true
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// SafeSendStatus fires successfully after pending message is sent
+	err = sender.SafeSendStatus(ctx, WorkerStatus{Code: WorkerStatusFinished})
+	require.NoError(t, err)
+	err = sender.Tick(ctx)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		msg, ok := msgSender.TryPop(masterNodeName, WorkerStatusUpdatedTopic(masterName))
+		if !ok {
+			return false
+		}
+		require.Equal(t, &WorkerStatusUpdatedMessage{FromWorkerID: workerID1, Epoch: 1}, msg)
+		return true
+	}, 2*time.Second, 10*time.Millisecond)
 }

--- a/lib/status_test.go
+++ b/lib/status_test.go
@@ -250,7 +250,7 @@ func TestStatusSenderSafeSend(t *testing.T) {
 	}()
 
 	msgSender := p2p.NewMockMessageSender()
-	metaClient := metadata.NewMetaMock()
+	metaClient := mockkv.NewMetaMock()
 
 	masterClient := newMasterClient(masterName, workerID1, msgSender, metaClient, clock.MonoNow(), func() error {
 		return nil

--- a/lib/worker.go
+++ b/lib/worker.go
@@ -220,14 +220,15 @@ func (w *DefaultBaseWorker) doPreInit(ctx context.Context) error {
 		return errors.Trace(err)
 	}
 
-	if err := w.statusSender.SafeSendStatus(ctx, WorkerStatus{Code: WorkerStatusInit}); err != nil {
-		return errors.Trace(err)
-	}
-
 	return nil
 }
 
 func (w *DefaultBaseWorker) doPostInit(ctx context.Context) error {
+	if err := w.statusSender.SafeSendStatus(
+		ctx, WorkerStatus{Code: WorkerStatusInit}); err != nil {
+		return errors.Trace(err)
+	}
+
 	w.startBackgroundTasks()
 	return nil
 }


### PR DESCRIPTION
- Separate the `SendStatus` into two sub functions, one of them will persist worker status first in a synchronous way, the other function still keeps the asynchronous style.
- Refactor `SafeSendStatus`, it will try to send status in the synchronous way until it is sucessful. This fixes a bug that when there exits a pending message in status sending buffer, the persist worker status could be overlapped with old status.
- Fix in demo job, worker status is not updated to correct value before exiting.