### PR TITLE
lib/worker: check worker is finished or stopped before timeout

### DIFF
--- a/lib/common.go
+++ b/lib/common.go
@@ -98,6 +98,17 @@ type WorkerStatus struct {
 	ExtBytes []byte `json:"ext-bytes"`
 }
 
+// InTerminateState returns whether worker is in a terminate state, including
+// finished, stopped, error.
+func (s *WorkerStatus) InTerminateState() bool {
+	switch s.Code {
+	case WorkerStatusFinished, WorkerStatusStopped, WorkerStatusError:
+		return true
+	default:
+		return false
+	}
+}
+
 func (s *WorkerStatus) Marshal() ([]byte, error) {
 	return json.Marshal(s)
 }

--- a/lib/common_test.go
+++ b/lib/common_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAdjustTimeoutConfig(t *testing.T) {
+	t.Parallel()
+
 	tc := TimeoutConfig{
 		workerTimeoutDuration:            time.Second * 3,
 		workerTimeoutGracefulDuration:    time.Second * 5,
@@ -24,4 +26,24 @@ func TestAdjustTimeoutConfig(t *testing.T) {
 	}
 	tc = tc.Adjust()
 	require.Equal(t, expected, tc)
+}
+
+func TestTerminateState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		code     WorkerStatusCode
+		expected bool
+	}{
+		{WorkerStatusNormal, false},
+		{WorkerStatusCreated, false},
+		{WorkerStatusInit, false},
+		{WorkerStatusError, true},
+		{WorkerStatusFinished, true},
+		{WorkerStatusStopped, true},
+	}
+	s := &WorkerStatus{}
+	for _, tc := range testCases {
+		s.Code = tc.code
+		require.Equal(t, tc.expected, s.InTerminateState())
+	}
 }

--- a/lib/worker_manager.go
+++ b/lib/worker_manager.go
@@ -280,9 +280,9 @@ func (m *workerManagerImpl) Tick(
 			onlinedWorkers = append(onlinedWorkers, workerInfo)
 		}
 
-		if workerInfo.hasTimedOut(m.clock, &m.timeoutConfig) {
+		status := m.statusReceivers[workerID].Status()
+		if workerInfo.hasTimedOut(m.clock, &m.timeoutConfig) || status.InTerminateState() {
 			offlinedWorkers = append(offlinedWorkers, workerInfo)
-			status := m.statusReceivers[workerID].Status()
 			m.tombstones[workerID] = &status
 			delete(m.workerInfos, workerID)
 		}


### PR DESCRIPTION
In worker manager, check worker status in each tick, when worker is in terminated state, call `OnWorkerOffline` directly, without waiting for worker heartbeat timeout.