### PR TITLE
add basic failover on DM sync unit

### DIFF
--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,0 +1,12 @@
+FROM golang:1.18-alpine as builder
+
+RUN apk add --no-cache gcompat
+
+COPY ./bin/master ./bin/
+COPY ./bin/executor ./bin/
+
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 && \
+    chmod +x /usr/local/bin/dumb-init
+
+ENTRYPOINT ["/usr/local/bin/dumb-init"]
+

--- a/lib/base_jobmaster.go
+++ b/lib/base_jobmaster.go
@@ -21,7 +21,7 @@ type BaseJobMaster interface {
 	OnError(err error)
 	MetaKVClient() metaclient.KVClient
 	GetWorkers() map[WorkerID]WorkerHandle
-	CreateWorker(workerType WorkerType, config WorkerConfig, cost model.RescUnit) (WorkerID, error)
+	CreateWorker(workerType WorkerType, config WorkerConfig, cost model.RescUnit, options ...CreateWorkerOptionFn) (WorkerID, error)
 	Workload() model.RescUnit
 	JobMasterID() MasterID
 	ID() worker.RunnableID
@@ -165,8 +165,8 @@ func (d *DefaultBaseJobMaster) OnError(err error) {
 	d.master.OnError(err)
 }
 
-func (d *DefaultBaseJobMaster) CreateWorker(workerType WorkerType, config WorkerConfig, cost model.RescUnit) (WorkerID, error) {
-	return d.master.CreateWorker(workerType, config, cost)
+func (d *DefaultBaseJobMaster) CreateWorker(workerType WorkerType, config WorkerConfig, cost model.RescUnit, options ...CreateWorkerOptionFn) (WorkerID, error) {
+	return d.master.CreateWorker(workerType, config, cost, options...)
 }
 
 func (d *DefaultBaseJobMaster) UpdateStatus(ctx context.Context, status libModel.WorkerStatus) error {

--- a/lib/master.go
+++ b/lib/master.go
@@ -89,7 +89,7 @@ type BaseMaster interface {
 	Close(ctx context.Context) error
 	OnError(err error)
 	// CreateWorker registers worker handler and dispatches worker to executor
-	CreateWorker(workerType WorkerType, config WorkerConfig, cost model.RescUnit) (WorkerID, error)
+	CreateWorker(workerType WorkerType, config WorkerConfig, cost model.RescUnit, options ...CreateWorkerOptionFn) (WorkerID, error)
 }
 
 type DefaultBaseMaster struct {
@@ -539,11 +539,34 @@ func (m *DefaultBaseMaster) prepareWorkerConfig(
 	return
 }
 
-func (m *DefaultBaseMaster) CreateWorker(workerType WorkerType, config WorkerConfig, cost model.RescUnit) (WorkerID, error) {
+type createWorkerOptions struct {
+	MustOnAnotherNode bool
+}
+
+type CreateWorkerOptionFn func(*createWorkerOptions)
+
+func MustOnAnotherNode() CreateWorkerOptionFn {
+	return func(o *createWorkerOptions) {
+		o.MustOnAnotherNode = true
+	}
+}
+
+func (m *DefaultBaseMaster) CreateWorker(
+	workerType WorkerType,
+	config WorkerConfig,
+	cost model.RescUnit,
+	options ...CreateWorkerOptionFn,
+) (WorkerID, error) {
+	o := &createWorkerOptions{}
+	for _, f := range options {
+		f(o)
+	}
+
 	log.L().Info("CreateWorker",
 		zap.Int64("worker-type", int64(workerType)),
 		zap.Any("worker-config", config),
-		zap.String("master-id", m.id))
+		zap.String("master-id", m.id),
+		zap.Any("options", o))
 
 	if !m.createWorkerQuota.TryConsume() {
 		return "", derror.ErrMasterConcurrencyExceeded.GenWithStackByArgs()
@@ -569,29 +592,42 @@ func (m *DefaultBaseMaster) CreateWorker(workerType WorkerType, config WorkerCon
 			workerID, libModel.WorkerStatus{Code: libModel.WorkerStatusError}, nil)
 		requestCtx, cancel := context.WithTimeout(context.Background(), createWorkerTimeout)
 		defer cancel()
-		// This following API should be refined.
-		resp, err := m.serverMasterClient.ScheduleTask(requestCtx, &pb.TaskSchedulerRequest{Tasks: []*pb.ScheduleTask{{
-			Task: &pb.TaskRequest{
-				Id: 0,
-			},
-			Cost: int64(cost),
-		}}},
-			// TODO (zixiong) make the timeout configurable
-			time.Second*10)
-		if err != nil {
-			err1 := m.Impl.OnWorkerDispatched(dispatchFailedDummyHandler, errors.Trace(err))
-			if err1 != nil {
-				m.OnError(errors.Trace(err1))
-			}
-			return
-		}
-		schedule := resp.GetSchedule()
-		if len(schedule) != 1 {
-			log.L().Panic("unexpected schedule result", zap.Any("schedule", schedule))
-		}
-		executorID := model.ExecutorID(schedule[0].ExecutorId)
 
-		err = m.executorClientManager.AddExecutor(executorID, schedule[0].Addr)
+		var (
+			executorID model.ExecutorID
+			addr       string
+		)
+
+		// when MustOnAnotherNode is true, we simply retry request until success or context timeout
+		for {
+			// This following API should be refined.
+			resp, err := m.serverMasterClient.ScheduleTask(requestCtx, &pb.TaskSchedulerRequest{Tasks: []*pb.ScheduleTask{{
+				Task: &pb.TaskRequest{
+					Id: 0,
+				},
+				Cost: int64(cost),
+			}}},
+				// TODO (zixiong) make the timeout configurable
+				time.Second*10)
+			if err != nil {
+				err1 := m.Impl.OnWorkerDispatched(dispatchFailedDummyHandler, errors.Trace(err))
+				if err1 != nil {
+					m.OnError(errors.Trace(err1))
+				}
+				return
+			}
+			schedule := resp.GetSchedule()
+			if len(schedule) != 1 {
+				log.L().Panic("unexpected schedule result", zap.Any("schedule", schedule))
+			}
+			executorID = model.ExecutorID(schedule[0].ExecutorId)
+			addr = schedule[0].Addr
+			if !o.MustOnAnotherNode || executorID != model.ExecutorID(m.nodeID) {
+				break
+			}
+		}
+
+		err = m.executorClientManager.AddExecutor(executorID, addr)
 		if err != nil {
 			err1 := m.Impl.OnWorkerDispatched(dispatchFailedDummyHandler, errors.Trace(err))
 			if err1 != nil {

--- a/lib/mock_master_util.go
+++ b/lib/mock_master_util.go
@@ -52,18 +52,12 @@ func MockBaseMaster(id MasterID, masterImpl MasterImpl) *DefaultBaseMaster {
 	return ret.(*DefaultBaseMaster)
 }
 
-func MockBaseMasterCreateWorker(
+func MockServerMasterScheduleTask(
 	t *testing.T,
 	master *DefaultBaseMaster,
-	workerType WorkerType,
-	config WorkerConfig,
 	cost model.RescUnit,
-	masterID MasterID,
-	workerID WorkerID,
 	executorID model.ExecutorID,
 ) {
-	master.uuidGen = uuid.NewMock()
-
 	expectedSchedulerReq := &pb.TaskSchedulerRequest{Tasks: []*pb.ScheduleTask{{
 		Task: &pb.TaskRequest{
 			Id: 0,
@@ -81,7 +75,22 @@ func MockBaseMasterCreateWorker(
 					ExecutorId: string(executorID),
 				},
 			},
-		}, nil)
+		}, nil).Once()
+}
+
+func MockBaseMasterCreateWorker(
+	t *testing.T,
+	master *DefaultBaseMaster,
+	workerType WorkerType,
+	config WorkerConfig,
+	cost model.RescUnit,
+	masterID MasterID,
+	workerID WorkerID,
+	executorID model.ExecutorID,
+) {
+	master.uuidGen = uuid.NewMock()
+
+	MockServerMasterScheduleTask(t, master, cost, executorID)
 
 	mockExecutorClient := &client.MockExecutorClient{}
 	err := master.executorClientManager.(*client.Manager).AddExecutorClient(executorID, mockExecutorClient)

--- a/sample/build_image_from_local.sh
+++ b/sample/build_image_from_local.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+current_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+docker build -f $current_dir/../Dockerfile-local -t dataflow:test $current_dir/..
+

--- a/test/e2e/dm-subtask-incr.toml
+++ b/test/e2e/dm-subtask-incr.toml
@@ -1,0 +1,80 @@
+is-sharding = false
+shard-mode = ""
+online-ddl = true
+shadow-table-rules = ["^_(.+)_(?:new|gho)$"]
+trash-table-rules = ["^_(.+)_(?:ghc|del|old)$"]
+online-ddl-scheme = ""
+case-sensitive = true
+collation_compatible = "loose"
+name = "df-test"
+mode = "incremental"
+ignore-checking-items = []
+source-id = "mysql-replica-01"
+server-id = 0
+flavor = "mysql"
+meta-schema = "dmmeta"
+heartbeat-update-interval = 12
+heartbeat-report-interval = 21
+enable-heartbeat = true
+timezone = ""
+relay-dir = ""
+use-relay = false
+mydumper-path = ""
+threads = 16
+chunk-filesize = "64"
+statement-size = 1000000
+rows = 1024
+where = ""
+skip-tz-utc = true
+extra-args = ""
+pool-size = 32
+dir = "/tmp/dumped_data"
+import-mode = "sql"
+on-duplicate = "replace"
+meta-file = ""
+worker-count = 32
+batch = 100
+queue-size = 512
+checkpoint-flush-interval = 15
+compact = false
+multiple-rows = false
+max-retry = 10
+auto-fix-gtid = true
+enable-gtid = false
+disable-detect = false
+safe-mode = true
+enable-ansi-quotes = false
+log-level = ""
+log-file = ""
+log-format = ""
+log-rotate = ""
+pprof-addr = ""
+status-addr = ""
+clean-dump-file = true
+ansi-quotes = true
+
+[meta]
+  binlog-name = "mysql-bin.000001"
+  binlog-pos = 4
+  binlog-gtid = ""
+
+[from]
+  host = "host.docker.internal"
+  port = 3306
+  user = "root"
+  password = "123456"
+
+[to]
+  host = "host.docker.internal"
+  port = 4000
+  user = "root"
+  password = ""
+
+[block-allow-list]
+  do-dbs = ["test"]
+
+[ValidatorCfg]
+  mode = "none"
+
+[experimental]
+  async-checkpoint-flush = true

--- a/test/e2e/e2e_dm_test.go
+++ b/test/e2e/e2e_dm_test.go
@@ -107,3 +107,62 @@ func TestDMSubtask(t *testing.T) {
 		return true
 	}, 5*time.Second, 500*time.Millisecond)
 }
+
+func TestDMIncrementalSubtask(t *testing.T) {
+	ctx := context.Background()
+	masterClient, err := client.NewMasterClient(ctx, []string{"127.0.0.1:10240"})
+	require.NoError(t, err)
+
+	mysqlCfg := util.DBConfig{
+		Host:     "127.0.0.1",
+		Port:     3306,
+		User:     "root",
+		Password: "123456",
+	}
+	tidbCfg := util.DBConfig{
+		Host:     "127.0.0.1",
+		Port:     4000,
+		User:     "root",
+		Password: "",
+	}
+
+	mysql, err := util.CreateDB(mysqlCfg)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, util.CloseDB(mysql))
+	}()
+	tidb, err := util.CreateDB(tidbCfg)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, util.CloseDB(tidb))
+	}()
+
+	// clean up
+	_, err = tidb.Exec("drop database if exists dmmeta")
+	require.NoError(t, err)
+	_, err = tidb.Exec("drop database if exists test")
+	require.NoError(t, err)
+	_, err = mysql.Exec("drop database if exists test")
+	require.NoError(t, err)
+	_, err = mysql.Exec("reset master")
+	require.NoError(t, err)
+
+	dmSubtask, err := ioutil.ReadFile("./dm-subtask-incr.toml")
+	require.NoError(t, err)
+	resp, err := masterClient.SubmitJob(ctx, &pb.SubmitJobRequest{
+		Tp:     pb.JobType_DM,
+		Config: dmSubtask,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.Err)
+
+	// incremental phase
+	_, err = mysql.Exec("create database test")
+	require.NoError(t, err)
+	_, err = mysql.Exec("create table test.t1(c int primary key)")
+	require.NoError(t, err)
+
+	// write something and manually restart container
+	// docker-compose -f ./1m3e.yaml restart server-executor-2
+	time.Sleep(time.Hour)
+}


### PR DESCRIPTION
Also, CreateWorker now has options. Currently only `MustOnAnotherNode`

I tested the basic failover