### PR TITLE
jobmanager: fix job master offline delay caused panic

### DIFF
--- a/lib/fake/fake_master.go
+++ b/lib/fake/fake_master.go
@@ -250,6 +250,10 @@ func (m *Master) OnWorkerMessage(worker lib.WorkerHandle, topic p2p.Topic, messa
 	return nil
 }
 
+func (m *Master) OnWorkerStatusUpdated(worker lib.WorkerHandle, newStatus *libModel.WorkerStatus) error {
+	return nil
+}
+
 func (m *Master) CloseImpl(ctx context.Context) error {
 	log.L().Info("FakeMaster: Close", zap.Stack("stack"))
 	return nil

--- a/servermaster/job_fsm_test.go
+++ b/servermaster/job_fsm_test.go
@@ -23,7 +23,7 @@ func TestJobFsmStateTrans(t *testing.T) {
 	worker := lib.NewTombstoneWorkerHandle(id, libModel.WorkerStatus{Code: libModel.WorkerStatusNormal}, nil)
 
 	// create new job, enter into WaitAckack job queue
-	fsm.JobDispatched(job)
+	fsm.JobDispatched(job, false)
 	require.Equal(t, 1, fsm.JobCount(pb.QueryJobResponse_dispatched))
 
 	// OnWorkerOnline, WaitAck -> Online

--- a/servermaster/jobmanager.go
+++ b/servermaster/jobmanager.go
@@ -156,7 +156,7 @@ func (jm *JobManagerImplV2) SubmitJob(ctx context.Context, req *pb.SubmitJobRequ
 		return resp
 	}
 
-	jm.JobFsm.JobDispatched(meta)
+	jm.JobFsm.JobDispatched(meta, false /*addFromFailover*/)
 	resp.JobIdStr = id
 	return resp
 }
@@ -240,7 +240,7 @@ func (jm *JobManagerImplV2) OnMasterRecovered(ctx context.Context) error {
 			log.L().Info("skip finished or stopped job", zap.Any("job", job))
 			continue
 		}
-		jm.JobFsm.JobDispatched(job)
+		jm.JobFsm.JobDispatched(job, true /*addFromFailover*/)
 		log.L().Info("recover job, move it to WaitAck job queue", zap.Any("job", job))
 	}
 	return nil

--- a/servermaster/jobmanager_test.go
+++ b/servermaster/jobmanager_test.go
@@ -67,7 +67,7 @@ func TestJobManagerPauseJob(t *testing.T) {
 
 	pauseWorkerID := "pause-worker-id"
 	meta := &lib.MasterMetaKVData{ID: pauseWorkerID}
-	mgr.JobFsm.JobDispatched(meta)
+	mgr.JobFsm.JobDispatched(meta, false)
 
 	mockWorkerHandler := &lib.MockWorkerHandler{WorkerID: pauseWorkerID}
 	mockWorkerHandler.On("SendMessage",


### PR DESCRIPTION
Close #266 

- When worker manager starts up, it loads all workers from meta store, but for these tombstone workers no worker offline will be triggered.
- The other workers added by Submit job will be always triggered worker offline.

So in job manager we only filter wait ack jobs for failover only when they are added during job manager failover.