### PR TITLE
p2p: add one more config in p2p server to avoid stream closed

### DIFF
--- a/pkg/p2p/server.go
+++ b/pkg/p2p/server.go
@@ -33,6 +33,7 @@ type (
 )
 
 // read only
+// TODO: should we expose a default config from p2pImpl package
 var defaultServerConfig = Config{
 	MaxPendingMessageCountPerTopic:       256,
 	MaxPendingTaskCount:                  102400,
@@ -41,6 +42,7 @@ var defaultServerConfig = Config{
 	WorkerPoolSize:                       4,
 	MaxPeerCount:                         1024,
 	WaitUnregisterHandleTimeoutThreshold: time.Millisecond * 100,
+	SendRateLimitPerStream:               1024.0,
 }
 
 // MessageRPCService is a background service wrapping a MessageServer instance.


### PR DESCRIPTION
Close #274 

- After this change in `golang.org/x/time` https://github.com/golang/time/commit/f0f3c7e86c11ca8f8b99d970e28445dda0b41195, the behavior of rate limiter with zero limit was changed.
- In dataflow engine, when we create a new p2p server, we didn't pass the value for `SendRateLimitPerStream` at 
    https://github.com/pingcap/tiflow/blob/fffe5a1049c8e14caa344cc8bece5648a22ca96c/pkg/p2p/server.go#L645, which will cause this line always fails for the second time it runs and the server receiving loop terminates.  
    https://github.com/pingcap/tiflow/blob/fffe5a1049c8e14caa344cc8bece5648a22ca96c/pkg/p2p/server.go#L659