### PR TITLE
jobmanager: reuse master API for failover of tombstone job master

### DIFF
--- a/servermaster/config.go
+++ b/servermaster/config.go
@@ -41,9 +41,6 @@ const (
 	defaultCampaignTimeout    = 5 * time.Second
 	defaultDiscoverTicker     = 3 * time.Second
 	defaultMetricInterval     = 15 * time.Second
-	// TODO: make it configurable, and must be larger than the
-	// workerTimeoutDuration (15s by default) in executor
-	defaultWorkerTimeout = 16 * time.Second
 
 	defaultPeerUrls            = "http://127.0.0.1:8291"
 	defaultInitialClusterState = embed.ClusterStateFlagNew

--- a/servermaster/job_fsm_test.go
+++ b/servermaster/job_fsm_test.go
@@ -21,13 +21,26 @@ func TestJobFsmStateTrans(t *testing.T) {
 		Config: []byte("simple config"),
 	}
 	worker := lib.NewTombstoneWorkerHandle(id, libModel.WorkerStatus{Code: libModel.WorkerStatusNormal}, nil)
+	createWorkerCount := 0
 
-	// create new job, enter into WaitAckack job queue
-	fsm.JobDispatched(job, false)
+	// Failover, job fsm loads tombstone job master
+	fsm.JobDispatched(job, true)
+	err := fsm.IterWaitAckJobs(func(job *lib.MasterMetaKVData) (string, error) {
+		createWorkerCount++
+		return id, nil
+	})
+	require.Equal(t, 1, createWorkerCount)
 	require.Equal(t, 1, fsm.JobCount(pb.QueryJobResponse_dispatched))
 
+	// job that is not added from failover won't be processed
+	err = fsm.IterWaitAckJobs(func(job *lib.MasterMetaKVData) (string, error) {
+		createWorkerCount++
+		return id, nil
+	})
+	require.Equal(t, 1, createWorkerCount)
+
 	// OnWorkerOnline, WaitAck -> Online
-	err := fsm.JobOnline(worker)
+	err = fsm.JobOnline(worker)
 	require.Nil(t, err)
 	require.Equal(t, 0, fsm.JobCount(pb.QueryJobResponse_dispatched))
 	require.Equal(t, 1, fsm.JobCount(pb.QueryJobResponse_online))

--- a/servermaster/job_fsm_test.go
+++ b/servermaster/job_fsm_test.go
@@ -29,6 +29,7 @@ func TestJobFsmStateTrans(t *testing.T) {
 		createWorkerCount++
 		return id, nil
 	})
+	require.Nil(t, err)
 	require.Equal(t, 1, createWorkerCount)
 	require.Equal(t, 1, fsm.JobCount(pb.QueryJobResponse_dispatched))
 
@@ -37,6 +38,7 @@ func TestJobFsmStateTrans(t *testing.T) {
 		createWorkerCount++
 		return id, nil
 	})
+	require.Nil(t, err)
 	require.Equal(t, 1, createWorkerCount)
 
 	// OnWorkerOnline, WaitAck -> Online

--- a/servermaster/jobmanager.go
+++ b/servermaster/jobmanager.go
@@ -12,6 +12,7 @@ import (
 	cvs "github.com/hanfei1991/microcosm/jobmaster/cvsJob"
 	"github.com/hanfei1991/microcosm/lib"
 	"github.com/hanfei1991/microcosm/pb"
+	"github.com/hanfei1991/microcosm/pkg/clock"
 	dcontext "github.com/hanfei1991/microcosm/pkg/context"
 	derrors "github.com/hanfei1991/microcosm/pkg/errors"
 	"github.com/hanfei1991/microcosm/pkg/meta/metaclient"
@@ -44,6 +45,8 @@ type JobManagerImplV2 struct {
 
 	masterMetaClient *lib.MasterMetadataClient
 	uuidGen          uuid.Generator
+	clocker          clock.Clock
+	tombstoneCleaned bool
 }
 
 func (jm *JobManagerImplV2) PauseJob(ctx context.Context, req *pb.PauseJobRequest) *pb.PauseJobResponse {
@@ -178,6 +181,7 @@ func NewJobManagerImplV2(
 		JobFsm:           NewJobFsm(),
 		uuidGen:          uuid.NewGenerator(),
 		masterMetaClient: cli,
+		clocker:          clock.New(),
 	}
 	impl.BaseMaster = lib.NewBaseMaster(
 		dctx,
@@ -217,13 +221,16 @@ func (jm *JobManagerImplV2) Tick(ctx context.Context) error {
 		return err
 	}
 
-	err = jm.JobFsm.IterWaitAckJobs(
-		func(job *lib.MasterMetaKVData) (string, error) {
-			return jm.BaseMaster.CreateWorker(
-				job.Tp, job, defaultJobMasterCost)
-		})
-	if err != nil {
-		return err
+	if !jm.tombstoneCleaned && jm.BaseMaster.IsMasterReady() {
+		err = jm.JobFsm.IterWaitAckJobs(
+			func(job *lib.MasterMetaKVData) (string, error) {
+				return jm.BaseMaster.CreateWorker(
+					job.Tp, job, defaultJobMasterCost)
+			})
+		if err != nil {
+			return err
+		}
+		jm.tombstoneCleaned = true
 	}
 
 	return nil

--- a/servermaster/jobmanager_test.go
+++ b/servermaster/jobmanager_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hanfei1991/microcosm/lib"
 	"github.com/hanfei1991/microcosm/pb"
+	"github.com/hanfei1991/microcosm/pkg/clock"
 	"github.com/hanfei1991/microcosm/pkg/errors"
 	mockkv "github.com/hanfei1991/microcosm/pkg/meta/kvclient/mock"
 	"github.com/hanfei1991/microcosm/pkg/uuid"
@@ -63,6 +64,7 @@ func TestJobManagerPauseJob(t *testing.T) {
 	mgr := &JobManagerImplV2{
 		BaseMaster: mockMaster.DefaultBaseMaster,
 		JobFsm:     NewJobFsm(),
+		clocker:    clock.New(),
 	}
 
 	pauseWorkerID := "pause-worker-id"


### PR DESCRIPTION
`BaseMaster` provides a `IsMasterReady` API, when this function returns, it means that all tombstone workers have been timeout, and can be recreated safely.

So we can remove the timeout detection in job manager and reuse existing API.