### PR TITLE
jobmanager: delete master meta when create worker returns error

### DIFF
--- a/lib/metadata.go
+++ b/lib/metadata.go
@@ -66,6 +66,12 @@ func (c *MasterMetadataClient) Store(ctx context.Context, data *MasterMetaKVData
 	return nil
 }
 
+func (c *MasterMetadataClient) Delete(ctx context.Context) error {
+	key := adapter.MasterMetaKey.Encode(c.masterID)
+	_, err := c.metaKVClient.Delete(ctx, key)
+	return errors.Trace(err)
+}
+
 // LoadAllMasters loads all job masters from metastore
 func (c *MasterMetadataClient) LoadAllMasters(ctx context.Context) ([]*MasterMetaKVData, error) {
 	resp, err := c.metaKVClient.Get(ctx, adapter.MasterMetaKey.Path(), metaclient.WithPrefix())
@@ -197,4 +203,13 @@ func StoreMasterMeta(
 	}
 
 	return metaClient.Store(ctx, meta)
+}
+
+func DeleteMasterMeta(
+	ctx context.Context,
+	metaKVClient metaclient.KVClient,
+	masterID MasterID,
+) error {
+	metaClient := NewMasterMetadataClient(masterID, metaKVClient)
+	return metaClient.Delete(ctx)
 }

--- a/lib/metadata_test.go
+++ b/lib/metadata_test.go
@@ -43,7 +43,7 @@ func TestMasterMetadata(t *testing.T) {
 	}
 }
 
-func TestStoreMasterMetadata(t *testing.T) {
+func TestOperateMasterMetadata(t *testing.T) {
 	t.Parallel()
 	var (
 		ctx          = context.Background()
@@ -51,9 +51,10 @@ func TestStoreMasterMetadata(t *testing.T) {
 		addr1        = "127.0.0.1:10000"
 		addr2        = "127.0.0.1:10001"
 		meta         = &MasterMetaKVData{
-			ID:   "master-1",
-			Tp:   FakeJobMaster,
-			Addr: addr1,
+			ID:         "master-1",
+			Tp:         FakeJobMaster,
+			Addr:       addr1,
+			StatusCode: MasterStatusInit,
 		}
 	)
 	loadMeta := func() *MasterMetaKVData {
@@ -73,6 +74,12 @@ func TestStoreMasterMetadata(t *testing.T) {
 	err = StoreMasterMeta(ctx, metaKVClient, meta)
 	require.NoError(t, err)
 	require.Equal(t, addr2, loadMeta().Addr)
+
+	err = DeleteMasterMeta(ctx, metaKVClient, meta.ID)
+	require.NoError(t, err)
+	// meta is not found in metastore, load meta will return a new master meta
+	require.Equal(t, "", loadMeta().Addr)
+	require.Equal(t, MasterStatusUninit, loadMeta().StatusCode)
 }
 
 func TestLoadAllWorkers(t *testing.T) {

--- a/servermaster/jobmanager.go
+++ b/servermaster/jobmanager.go
@@ -154,6 +154,11 @@ func (jm *JobManagerImplV2) SubmitJob(ctx context.Context, req *pb.SubmitJobRequ
 	id, err = jm.BaseMaster.CreateWorker(
 		meta.Tp, meta, defaultJobMasterCost)
 	if err != nil {
+		err2 := lib.DeleteMasterMeta(ctx, jm.BaseMaster.MetaKVClient(), meta.ID)
+		if err2 != nil {
+			log.L().Error("failed to delete master meta", zap.Error(err2))
+		}
+
 		log.L().Error("create job master met error", zap.Error(err))
 		resp.Err = derrors.ToPBError(err)
 		return resp

--- a/servermaster/jobmanager.go
+++ b/servermaster/jobmanager.go
@@ -156,6 +156,7 @@ func (jm *JobManagerImplV2) SubmitJob(ctx context.Context, req *pb.SubmitJobRequ
 	if err != nil {
 		err2 := lib.DeleteMasterMeta(ctx, jm.BaseMaster.MetaKVClient(), meta.ID)
 		if err2 != nil {
+			// TODO: add more GC mechanism if master meta is failed to delete
 			log.L().Error("failed to delete master meta", zap.Error(err2))
 		}
 

--- a/servermaster/jobmanager_test.go
+++ b/servermaster/jobmanager_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hanfei1991/microcosm/lib"
+	"github.com/hanfei1991/microcosm/model"
 	"github.com/hanfei1991/microcosm/pb"
 	"github.com/hanfei1991/microcosm/pkg/clock"
 	"github.com/hanfei1991/microcosm/pkg/errors"
@@ -53,22 +54,31 @@ func TestJobManagerSubmitJob(t *testing.T) {
 	require.Equal(t, pb.QueryJobResponse_pending, queryResp.Status)
 }
 
+type mockBaseMasterCreateWorkerFailed struct {
+	*lib.MockMasterImpl
+}
+
+func (m *mockBaseMasterCreateWorkerFailed) CreateWorker(
+	workerType lib.WorkerType, config lib.WorkerConfig, cost model.RescUnit,
+) (lib.WorkerID, error) {
+	return "", errors.ErrMasterConcurrencyExceeded.FastGenByArgs()
+}
+
 func TestCreateWorkerReturnError(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	mockMaster := lib.NewMockMasterImpl("", "create-worker-with-errro")
-	mockMaster.DefaultBaseMaster.
-		On("CreateWorker", mock.Anything, mock.Anything, mock.Anything).
-		Return("", errors.ErrMasterConcurrencyExceeded.FastGenByArgs())
+	masterImpl := lib.NewMockMasterImpl("", "create-worker-with-error")
+	mockMaster := &mockBaseMasterCreateWorkerFailed{
+		MockMasterImpl: masterImpl,
+	}
 	mgr := &JobManagerImplV2{
-		BaseMaster: mockMaster.DefaultBaseMaster,
+		BaseMaster: mockMaster,
 		JobFsm:     NewJobFsm(),
 		uuidGen:    uuid.NewGenerator(),
 	}
-	// set master impl to JobManagerImplV2
 	mockMaster.Impl = mgr
 	err := mockMaster.Init(ctx)
 	require.Nil(t, err)
@@ -77,7 +87,8 @@ func TestCreateWorkerReturnError(t *testing.T) {
 		Config: []byte("{\"srcHost\":\"0.0.0.0:1234\", \"dstHost\":\"0.0.0.0:1234\", \"srcDir\":\"data\", \"dstDir\":\"data1\"}"),
 	}
 	resp := mgr.SubmitJob(ctx, req)
-	require.Nil(t, resp.Err)
+	require.NotNil(t, resp.Err)
+	require.Regexp(t, ".*ErrMasterConcurrencyExceeded.*", resp.Err.Message)
 }
 
 func TestJobManagerPauseJob(t *testing.T) {


### PR DESCRIPTION
Fix a problem that when create worker returns error during user submit job, the metadata of job master is still kept in metastore. And if the job manager transfers, the failed job master will be failover.
Just remove the master meta if a job is failed to create.