### PR TITLE
pkg: fix require.fail parameter

### DIFF
--- a/pkg/srvdiscovery/runner_test.go
+++ b/pkg/srvdiscovery/runner_test.go
@@ -70,9 +70,8 @@ func TestDiscoveryRunner(t *testing.T) {
 					break check
 				}
 			case <-time.After(time.Second):
-				require.Fail(t,
-					"not enough peer update received, received: %d, expected: %d",
-					nodesOn, runnerN-i-1)
+				require.Failf(t, "not enough peer update received",
+					"received: %d, expected: %d", nodesOn, runnerN-i-1)
 			}
 		}
 	}
@@ -101,9 +100,8 @@ func TestDiscoveryRunner(t *testing.T) {
 					break check2
 				}
 			case <-time.After(time.Second):
-				require.Fail(t,
-					"not enough peer update received, received: %d, expected: %d",
-					nodesOn, runnerN)
+				require.Failf(t, "not enough peer update received",
+					"received: %d, expected: %d", nodesOn, runnerN)
 			}
 		}
 	}


### PR DESCRIPTION
Fix the following panic in unit test.

Should print error message instead of panic, use correct parameters in `require.Fail` or `require.Failf`

```go
--- FAIL: TestDiscoveryRunner (8.60s)
panic: interface conversion: interface {} is int, not string [recovered]
	panic: interface conversion: interface {} is int, not string

goroutine 124 [running]:
testing.tRunner.func1.2({0x2733340, 0xc0006c5920})
	/opt/hostedtoolcache/go/1.18.0/x64/src/testing/testing.go:1389 +0x[366](https://github.com/hanfei1991/microcosm/runs/6052297129?check_suite_focus=true#step:4:366)
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.18.0/x64/src/testing/testing.go:1392 +0x5d2
panic({0x2733340, 0xc0006c5920})
	/opt/hostedtoolcache/go/1.18.0/x64/src/runtime/panic.go:844 +0x258
github.com/stretchr/testify/assert.messageFromMsgAndArgs({0xc000895e18, 0x2, 0x2})
	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.7.1/assert/assertions.go:191 +0x1aa
github.com/stretchr/testify/assert.Fail({0x7f51100a1120, 0xc0007744e0}, {0x2a4a180, 0x3b}, {0xc000895e18, 0x2, 0x2})
	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.7.1/assert/assertions.go:257 +0x271
github.com/stretchr/testify/require.Fail({0x31a1030, 0xc0007744e0}, {0x2a4a180, 0x3b}, {0xc000895e18, 0x2, 0x2})
	/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.7.1/require/require.go:412 +0xa5
github.com/hanfei1991/microcosm/pkg/srvdiscovery.TestDiscoveryRunner(0xc0007744e0)
	/home/runner/work/microcosm/microcosm/pkg/srvdiscovery/runner_test.go:104 +0x6b4
testing.tRunner(0xc0007744e0, 0x2aa2820)
	/opt/hostedtoolcache/go/1.18.0/x64/src/testing/testing.go:1439 +0x214
created by testing.(*T).Run
	/opt/hostedtoolcache/go/1.18.0/x64/src/testing/testing.go:1486 +0x725
FAIL	github.com/hanfei1991/microcosm/pkg/srvdiscovery	8.766s
```