### PR TITLE
lib/master: optimize for recovering with no worker

### DIFF
--- a/lib/master/worker_manager.go
+++ b/lib/master/worker_manager.go
@@ -148,6 +148,14 @@ func (m *WorkerManager) InitAfterRecover(ctx context.Context) error {
 		return err
 	}
 
+	if len(allPersistedWorkers) == 0 {
+		// Fast path when there is no worker.
+		m.mu.Lock()
+		m.state = workerManagerReady
+		m.mu.Unlock()
+		return nil
+	}
+
 	m.mu.Lock()
 	for workerID, status := range allPersistedWorkers {
 		entry := newWaitingWorkerEntry(workerID, status)

--- a/lib/master/worker_manager_test.go
+++ b/lib/master/worker_manager_test.go
@@ -379,3 +379,17 @@ func TestRecoverAfterFailoverFast(t *testing.T) {
 	require.Contains(t, suite.manager.GetWorkers(), "worker-1")
 	suite.Close()
 }
+
+func TestRecoverWithNoWorker(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	suite := NewWorkerManageTestSuite(false)
+
+	// Since there is no worker info in the metastore,
+	// recovering should be very fast.
+	// Since we are using a mock clock, and we are NOT advancing it,
+	// InitAfterRecover returning at all would indicate a successful test.
+	err := suite.manager.InitAfterRecover(ctx)
+	require.NoError(t, err)
+}

--- a/lib/master/worker_manager_test.go
+++ b/lib/master/worker_manager_test.go
@@ -392,4 +392,6 @@ func TestRecoverWithNoWorker(t *testing.T) {
 	// InitAfterRecover returning at all would indicate a successful test.
 	err := suite.manager.InitAfterRecover(ctx)
 	require.NoError(t, err)
+
+	suite.Close()
 }


### PR DESCRIPTION
- Add a fast path for master failover when there is no existing worker in the metastore.