### PR TITLE
servermaster: set initialized to true after leader runs

### DIFF
--- a/lib/master/worker_entry.go
+++ b/lib/master/worker_entry.go
@@ -82,10 +82,8 @@ func newWaitingWorkerEntry(
 	return newWorkerEntry(id, "", time.Time{}, workerEntryWait, lastStatus)
 }
 
+// String implements fmt.Stringer, note the implementation is not thread safe
 func (e *workerEntry) String() string {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
 	return fmt.Sprintf("{worker-id:%s, executor-id:%s, state:%d}",
 		e.id, e.executorID, e.state)
 }

--- a/pkg/rpcutil/server.go
+++ b/pkg/rpcutil/server.go
@@ -146,7 +146,8 @@ func (h PreRPCHook[T]) checkInitialized(respPointer interface{}) (shouldRet bool
 		errInRefelct := reflect.ValueOf(&pb.Error{
 			Code: pb.ErrorCode_MasterNotReady,
 		})
-		reflect.ValueOf(respPointer).Elem().FieldByName("Err").Set(errInRefelct)
+		reflect.Indirect(reflect.ValueOf(respPointer)).Elem().
+			FieldByName("Err").Set(errInRefelct)
 		return true
 	}
 	return false

--- a/servermaster/campaign_test.go
+++ b/servermaster/campaign_test.go
@@ -59,7 +59,7 @@ func TestLeaderLoopSuccess(t *testing.T) {
 		s.id,
 		&s.leader,
 		s.masterCli,
-		&s.initialized,
+		&s.leaderInitialized,
 		s.rpcLogRL,
 	)
 	s.masterRPCHook = preRPCHook
@@ -114,7 +114,7 @@ func TestLeaderLoopMeetStaleData(t *testing.T) {
 		s.id,
 		&s.leader,
 		s.masterCli,
-		&s.initialized,
+		&s.leaderInitialized,
 		s.rpcLogRL,
 	)
 	s.masterRPCHook = preRPCHook
@@ -185,7 +185,7 @@ func TestLeaderLoopWatchLeader(t *testing.T) {
 			s.id,
 			&s.leader,
 			s.masterCli,
-			&s.initialized,
+			&s.leaderInitialized,
 			s.rpcLogRL,
 		)
 		s.masterRPCHook = preRPCHook


### PR DESCRIPTION
This PR fixes several bugs in server master and worker manger

- Set server master `leaderInitialized` after run leader service runs
- Pre allocate response struct before calling `PreRPC` to avoid assigning to an empty ptr.
- Remove lock acquiring in workerEntry.String, because it can be accessed in a locked path, which will cause deadlock, such as L136 and L 144, https://github.com/hanfei1991/microcosm/blob/5c44fa8091ead367a0ee1f1dd52d9f9d56e6659a/lib/master/worker_entry.go#L135-L145
- Another deadlock in worker manger, which is caused by panic in inner path, and lock is not released in outer path, so extract a `checkWorkerEntriesOnce` function.
- Refine the fast path for no worker logic during worker manger failover, it is a temporary fix for finished worker, we need to refine logic of worker manager failover with different kinds of worker.