### PR TITLE
pkg: decrease concurrent size to avoid unit test timeout

### DIFF
--- a/pkg/srvdiscovery/runner.go
+++ b/pkg/srvdiscovery/runner.go
@@ -11,6 +11,10 @@ import (
 
 // DiscoveryRunner defines an interface to run Discovery service
 type DiscoveryRunner interface {
+	// ResetDiscovery creates a new discovery service, close the old discovery
+	// watcher and creates a new watcher.
+	// if resetSession is true, the session of discovery runner will be recreated
+	// and returned.
 	ResetDiscovery(ctx context.Context, resetSession bool) (Session, error)
 	GetWatcher() <-chan WatchResp
 	// returns current snapshot, DiscoveryRunner maintains this as snapshot plus
@@ -18,6 +22,7 @@ type DiscoveryRunner interface {
 	// consume more memory, but since it contains node address information only,
 	// the memory consumption is acceptable.
 	GetSnapshot() Snapshot
+	// ApplyWatchResult applies changed ServiceResource to the snapshot of runner
 	ApplyWatchResult(WatchResp)
 }
 

--- a/pkg/srvdiscovery/runner_test.go
+++ b/pkg/srvdiscovery/runner_test.go
@@ -30,14 +30,14 @@ func TestDiscoveryRunner(t *testing.T) {
 		require.Nil(t, err)
 		return NewDiscoveryRunnerImpl(
 			client,
-			3,
+			5,
 			time.Millisecond*50,
 			adapter.NodeInfoKeyAdapter.Encode(string(res.ID)),
 			resStr,
 		)
 	}
 
-	runnerN := 20
+	runnerN := 5
 	runners := make([]DiscoveryRunner, 0, runnerN)
 	for i := 0; i < runnerN; i++ {
 		runners = append(runners, newNodeOnline(i))


### PR DESCRIPTION
Close #331

Use fewer runners in unit test, the failed case is often caused by timeout.