### PR TITLE
lib/doc: add worker_entry_fsm.puml

### DIFF
--- a/lib/doc/worker_entry_fsm.puml
+++ b/lib/doc/worker_entry_fsm.puml
@@ -1,0 +1,23 @@
+@startuml
+state c <<choice>>
+[*] --> c
+c --> workerEntryCreated: New
+c --> workerEntryWait: Failover
+
+workerEntryCreated: ExpireAt = time.Now() + delta
+workerEntryWait: ExpireAt is unset while waiting for heartbeat.
+
+workerEntryCreated --> workerEntryNormal: Heartbeat
+workerEntryWait --> workerEntryNormal: Heartbeat
+
+workerEntryNormal: ExpireAt = time.Now() + delta
+workerEntryNormal --> workerEntryNormal: Heartbeat
+
+workerEntryOffline: worker is considered dead.
+workerEntryNormal --> workerEntryOffline: ExpireAt is reached
+workerEntryCreated --> workerEntryOffline: ExpireAt is reached
+
+workerEntryTombstone: Worker is dead and the business \nlogic can remove meta.
+workerEntryOffline --> workerEntryTombstone: OnWorkerOffline callback is run.
+workerEntryWait --> workerEntryTombstone: Delta passed after failover.
+@enduml

--- a/lib/master/worker_entry.go
+++ b/lib/master/worker_entry.go
@@ -26,6 +26,9 @@ const (
 	workerEntryTombstone
 )
 
+// The following is the state-transition diagram.
+// Refer to ../doc/worker_entry_fsm.puml for a UML version.
+//
 // workerEntryCreated            workerEntryWait
 //      │  │                            │  │
 //      │  │                            │  │


### PR DESCRIPTION
- Add a UML version of the state-transition diagram for `workerEntry` used in `WorkerManager`, which is the state management part of `BaseMaster`.

![image](https://user-images.githubusercontent.com/18745285/164970962-b1d6a24d-dd63-414f-8895-5bc7183a7ba0.png)
