### PR TITLE
e2e: add one more fake job test, to prepare for node failure test

### DIFF
--- a/.github/workflows/dataflow_engine_e2e.yaml
+++ b/.github/workflows/dataflow_engine_e2e.yaml
@@ -39,6 +39,31 @@ jobs:
         if: ${{ failure() }}
         run: docker-compose -f $GITHUB_WORKSPACE/sample/3m3e.yaml logs -t
 
+  Node-failure-workflow:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Build images
+        run: $GITHUB_WORKSPACE/sample/prepare.sh
+
+      - name: Run containers
+        run: docker-compose -f $GITHUB_WORKSPACE/sample/3m3e.yaml up -d
+
+      - name: Run tests
+        run: |
+          cd $GITHUB_WORKSPACE/test/e2e
+          go test -count=1 -v -run=TestNodeFailure
+
+      - name: Try to dump container logs
+        if: ${{ failure() }}
+        run: docker-compose -f $GITHUB_WORKSPACE/sample/3m3e.yaml logs -t
+
   DM-workflow:
     runs-on: ubuntu-latest
 

--- a/lib/fake/fake_master.go
+++ b/lib/fake/fake_master.go
@@ -22,18 +22,37 @@ import (
 	"github.com/hanfei1991/microcosm/pkg/p2p"
 )
 
+/*
+Fake job has two business logic in each fake worker
+
+- By default the worker will increase a counter by one in each tick. In the task
+  config it receives a target tick count, if the counter reaches target, the task
+  will stop.
+- Besides if `EtcdWatchEnable` is true in task config, for each worker will watch
+  the key change of `WatchPrefix+WorkerIndex`, record the changed count of this
+  key and latest value of this key.
+
+- WorkerIndex: fake job always spawns `WorkerCount` workers, each worker has a
+  unique index from 0 to `WorkerCount-1`
+*/
+
 // Config represents the job config of fake master
 type Config struct {
 	JobName     string `json:"job-name"`
 	WorkerCount int    `json:"worker-count"`
 	TargetTick  int    `json:"target-tick"`
+
+	EtcdWatchEnable bool     `json:"etcd-watch-enable"`
+	EtcdEndpoints   []string `json:"etcd-endpoints"`
+	EtcdWatchPrefix string   `json:"etcd-watch-prefix"`
 }
 
-type checkpoint struct {
-	Ticks map[int]int64 `json:"ticks"`
+type Checkpoint struct {
+	Ticks           map[int]int64          `json:"ticks"`
+	EtcdCheckpoints map[int]EtcdCheckpoint `json:"etcd-checkpoints"`
 }
 
-func (cp *checkpoint) String() string {
+func (cp *Checkpoint) String() string {
 	data, err := json.Marshal(cp)
 	if err != nil {
 		log.L().Warn("checkpoint marshal failed", zap.Error(err))
@@ -54,7 +73,7 @@ type Master struct {
 	workerID2BusinessID map[libModel.WorkerID]int
 	pendingWorkerSet    map[libModel.WorkerID]int
 	statusRateLimiter   *rate.Limiter
-	status              map[libModel.WorkerID]int64
+	status              map[libModel.WorkerID]*dummyWorkerStatus
 	finishedSet         map[libModel.WorkerID]int
 	config              *Config
 	statusCode          struct {
@@ -153,10 +172,7 @@ OUT:
 					continue OUT
 				}
 			}
-			wcfg := &WorkerConfig{
-				ID:         i,
-				TargetTick: int64(m.config.TargetTick),
-			}
+			wcfg := m.genWorkerConfig(i, 0, 0)
 			err := m.createWorker(wcfg)
 			if err != nil {
 				return err
@@ -199,8 +215,8 @@ func (m *Master) tickedCheckWorkers(ctx context.Context) error {
 			}
 		}
 		// load checkpoint if it exists
-		ckpt := &checkpoint{}
-		resp, metaErr := m.MetaKVClient().Get(ctx, m.checkpointKey())
+		ckpt := &Checkpoint{}
+		resp, metaErr := m.MetaKVClient().Get(ctx, CheckpointKey(m.workerID))
 		if metaErr != nil {
 			log.L().Warn("failed to load checkpoint", zap.Error(metaErr))
 		} else {
@@ -213,13 +229,14 @@ func (m *Master) tickedCheckWorkers(ctx context.Context) error {
 		for i, worker := range m.workerList {
 			// create new worker for non-active worker
 			if worker == nil {
-				wcfg := &WorkerConfig{
-					ID:         i,
-					TargetTick: int64(m.config.TargetTick),
-				}
+				var startTick, startRevision int64
 				if tick, ok := ckpt.Ticks[i]; ok {
-					wcfg.StartTick = tick
+					startTick = tick
 				}
+				if etcdCkpt, ok := ckpt.EtcdCheckpoints[i]; ok {
+					startRevision = etcdCkpt.Revision
+				}
+				wcfg := m.genWorkerConfig(i, startTick, startRevision)
 				if err := m.createWorker(wcfg); err != nil {
 					return errors.Trace(err)
 				}
@@ -239,7 +256,7 @@ func (m *Master) tickedCheckWorkers(ctx context.Context) error {
 					return err
 				}
 			}
-			m.status[worker.ID()] = dws.Tick
+			m.status[worker.ID()] = dws
 		}
 	}
 
@@ -250,7 +267,7 @@ func (m *Master) tickedCheckStatus(ctx context.Context) error {
 	if m.statusRateLimiter.Allow() {
 		log.L().Info("FakeMaster: Tick", zap.Any("status", m.status))
 		// save checkpoint, which is used in business only
-		_, metaErr := m.MetaKVClient().Put(ctx, m.checkpointKey(), m.genCheckpoint().String())
+		_, metaErr := m.MetaKVClient().Put(ctx, CheckpointKey(m.workerID), m.genCheckpoint().String())
 		if metaErr != nil {
 			log.L().Warn("update checkpoint with error", zap.Error(metaErr))
 		}
@@ -342,17 +359,16 @@ func (m *Master) OnWorkerOffline(worker lib.WorkerHandle, reason error) error {
 
 	log.L().Info("FakeMaster: OnWorkerOffline",
 		zap.String("worker-id", worker.ID()), zap.Error(reason))
-	var startTick int64
+	var startTick, startRevision int64
 	if ws, err := parseExtBytes(worker.Status().ExtBytes); err != nil {
 		log.L().Warn("failed to parse worker ext bytes", zap.Error(err))
 	} else {
 		startTick = ws.Tick
+		if ws.EtcdCheckpoint != nil {
+			startRevision = ws.EtcdCheckpoint.Revision
+		}
 	}
-	wcfg := &WorkerConfig{
-		ID:         index,
-		StartTick:  startTick,
-		TargetTick: int64(m.config.TargetTick),
-	}
+	wcfg := m.genWorkerConfig(index, startTick, startRevision)
 	return m.createWorker(wcfg)
 }
 
@@ -411,20 +427,40 @@ func parseExtBytes(data []byte) (*dummyWorkerStatus, error) {
 	return dws, err
 }
 
-func (m *Master) checkpointKey() string {
-	return strings.Join([]string{"fake-master", "checkpoint", m.workerID}, "/")
+func CheckpointKey(id libModel.MasterID) string {
+	return strings.Join([]string{"fake-master", "checkpoint", id}, "/")
 }
 
-func (m *Master) genCheckpoint() *checkpoint {
+func (m *Master) genCheckpoint() *Checkpoint {
 	m.workerListMu.Lock()
 	defer m.workerListMu.Unlock()
-	cp := &checkpoint{Ticks: make(map[int]int64)}
-	for wid, tick := range m.status {
+	cp := &Checkpoint{
+		Ticks:           make(map[int]int64),
+		EtcdCheckpoints: make(map[int]EtcdCheckpoint),
+	}
+	for wid, status := range m.status {
 		if businessID, ok := m.workerID2BusinessID[wid]; ok {
-			cp.Ticks[businessID] = tick
+			cp.Ticks[businessID] = status.Tick
+			if status.EtcdCheckpoint != nil {
+				cp.EtcdCheckpoints[businessID] = *status.EtcdCheckpoint
+			} else {
+				cp.EtcdCheckpoints[businessID] = EtcdCheckpoint{}
+			}
 		}
 	}
 	return cp
+}
+
+func (m *Master) genWorkerConfig(index int, startTick, startRevision int64) *WorkerConfig {
+	return &WorkerConfig{
+		ID:                index,
+		StartTick:         startTick,
+		TargetTick:        int64(m.config.TargetTick),
+		EtcdWatchEnable:   m.config.EtcdWatchEnable,
+		EtcdEndpoints:     m.config.EtcdEndpoints,
+		EtcdWatchPrefix:   m.config.EtcdWatchPrefix,
+		EtcdWatchRevision: startRevision,
+	}
 }
 
 func NewFakeMaster(ctx *dcontext.Context, workerID libModel.WorkerID, masterID libModel.MasterID, config lib.WorkerConfig) *Master {
@@ -437,7 +473,7 @@ func NewFakeMaster(ctx *dcontext.Context, workerID libModel.WorkerID, masterID l
 		workerID2BusinessID: make(map[libModel.WorkerID]int),
 		config:              masterConfig,
 		statusRateLimiter:   rate.NewLimiter(rate.Every(time.Second*3), 1),
-		status:              make(map[libModel.WorkerID]int64),
+		status:              make(map[libModel.WorkerID]*dummyWorkerStatus),
 		finishedSet:         make(map[libModel.WorkerID]int),
 		ctx:                 ctx.Context,
 		clocker:             clock.New(),

--- a/test/e2e/e2e_node_chaos_test.go
+++ b/test/e2e/e2e_node_chaos_test.go
@@ -60,7 +60,7 @@ func TestNodeFailure(t *testing.T) {
 		return true
 	}, time.Second*60, time.Second*2)
 
-	sourceUpdateCount := 10
+	sourceUpdateCount := 3
 	sourceValue := "value"
 	for i := 0; i < sourceUpdateCount; i++ {
 		for j := 0; j < cfg.WorkerCount; j++ {

--- a/test/e2e/e2e_node_chaos_test.go
+++ b/test/e2e/e2e_node_chaos_test.go
@@ -1,0 +1,248 @@
+package e2e_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/log"
+	"github.com/stretchr/testify/require"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	"github.com/hanfei1991/microcosm/client"
+	"github.com/hanfei1991/microcosm/lib/fake"
+	"github.com/hanfei1991/microcosm/pb"
+	"github.com/hanfei1991/microcosm/pkg/meta/kvclient"
+	"github.com/hanfei1991/microcosm/pkg/meta/metaclient"
+	"github.com/hanfei1991/microcosm/pkg/tenant"
+)
+
+type utCli struct {
+	// used to operate with server master, such as submit job
+	masterCli client.MasterClient
+	// used to query metadata which is stored from business logic
+	metaCli metaclient.KVClient
+	// used to write to etcd to simulate the business of fake job, this etcd client
+	// reuses the endpoints of user meta KV.
+	fakeJobCli *clientv3.Client
+	fakeJobCfg *fakeJobConfig
+}
+
+type fakeJobConfig struct {
+	etcdEndpoints []string
+	workerCount   int
+	keyPrefix     string
+}
+
+func NewUTCli(
+	ctx context.Context, masterAddrs, userMetaAddrs []string, cfg *fakeJobConfig,
+) (*utCli, error) {
+	masterCli, err := client.NewMasterClient(ctx, masterAddrs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	conf := metaclient.StoreConfigParams{Endpoints: userMetaAddrs}
+	userRawKVClient, err := kvclient.NewKVClient(&conf)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	metaCli := kvclient.NewPrefixKVClient(userRawKVClient, tenant.DefaultUserTenantID)
+
+	fakeJobCli, err := clientv3.New(clientv3.Config{
+		Endpoints:   userMetaAddrs,
+		Context:     ctx,
+		DialTimeout: 3 * time.Second,
+		DialOptions: []grpc.DialOption{},
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return &utCli{
+		masterCli:  masterCli,
+		metaCli:    metaCli,
+		fakeJobCli: fakeJobCli,
+		fakeJobCfg: cfg,
+	}, nil
+}
+
+func (cli *utCli) createJob(ctx context.Context, tp pb.JobType, config []byte) (string, error) {
+	req := &pb.SubmitJobRequest{Tp: tp, Config: config}
+	resp, err := cli.masterCli.SubmitJob(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	if resp.Err != nil {
+		return "", errors.New(resp.Err.String())
+	}
+	return resp.JobIdStr, nil
+}
+
+func (cli *utCli) pauseJob(ctx context.Context, jobID string) error {
+	req := &pb.PauseJobRequest{JobIdStr: jobID}
+	resp, err := cli.masterCli.PauseJob(ctx, req)
+	if err != nil {
+		return err
+	}
+	if resp.Err != nil {
+		return errors.New(resp.Err.String())
+	}
+	return nil
+}
+
+func (cli *utCli) checkJobStatus(
+	ctx context.Context, jobID string, expectedStatus pb.QueryJobResponse_JobStatus,
+) (bool, error) {
+	req := &pb.QueryJobRequest{JobId: jobID}
+	resp, err := cli.masterCli.QueryJob(ctx, req)
+	if err != nil {
+		return false, err
+	}
+	if resp.Err != nil {
+		return false, errors.New(resp.Err.String())
+	}
+	return resp.Status == expectedStatus, nil
+}
+
+func (cli *utCli) updateFakeJobKey(ctx context.Context, id int, value string) error {
+	key := fmt.Sprintf("%s%d", cli.fakeJobCfg.keyPrefix, id)
+	_, err := cli.fakeJobCli.Put(ctx, key, value)
+	return errors.Trace(err)
+}
+
+func (cli *utCli) getFakeJobCheckpoint(
+	ctx context.Context, masterID string, jobIndex int,
+) (*fake.Checkpoint, error) {
+	ckptKey := fake.CheckpointKey(masterID)
+	resp, metaErr := cli.metaCli.Get(ctx, ckptKey)
+	if metaErr != nil {
+		return nil, errors.New(metaErr.Error())
+	}
+	if len(resp.Kvs) == 0 {
+		return nil, errors.New("no checkpoint found")
+	}
+	checkpoint := &fake.Checkpoint{}
+	err := json.Unmarshal(resp.Kvs[0].Value, checkpoint)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return checkpoint, nil
+}
+
+func (cli *utCli) checkFakeJobTick(
+	ctx context.Context, masterID string, jobIndex int, target int64,
+) error {
+	ckpt, err := cli.getFakeJobCheckpoint(ctx, masterID, jobIndex)
+	if err != nil {
+		return err
+	}
+	if tick, ok := ckpt.Ticks[jobIndex]; !ok {
+		return errors.Errorf("job %d not found in checkpoint %v", jobIndex, ckpt)
+	} else {
+		if tick < target {
+			return errors.Errorf("tick %d not reaches target %d", tick, target)
+		}
+	}
+	return nil
+}
+
+func (cli *utCli) checkFakeJobKey(
+	ctx context.Context, masterID string, jobIndex int, expectedMvcc int, expectedValue string,
+) error {
+	checkpoint, err := cli.getFakeJobCheckpoint(ctx, masterID, jobIndex)
+	if err != nil {
+		return err
+	}
+	if ckpt, ok := checkpoint.EtcdCheckpoints[jobIndex]; !ok {
+		return errors.Errorf("job %d not found in checkpoint %v", jobIndex, checkpoint)
+	} else {
+		if ckpt.Value != expectedValue {
+			return errors.Errorf("value not equals, expected: %s, actual: %s", expectedValue, ckpt.Value)
+		}
+		if ckpt.Mvcc != expectedMvcc {
+			return errors.Errorf("mvcc not equals, expected: %d, actual: %d", expectedMvcc, ckpt.Mvcc)
+		}
+	}
+
+	return nil
+}
+
+func TestNodeFailure(t *testing.T) {
+	// TODO: make the following variables configurable
+	var (
+		masterAddrs              = []string{"127.0.0.1:10245", "127.0.0.1:10246", "127.0.0.1:10247"}
+		userMetaAddrs            = []string{"127.0.0.1:12479"}
+		userMetaAddrsInContainer = []string{"user-etcd-standalone:2379"}
+	)
+
+	ctx := context.Background()
+	cfg := &fake.Config{
+		JobName:     "test-node-failure",
+		WorkerCount: 5,
+		// use a large enough target tick to ensure the fake job long running
+		TargetTick:      10000000,
+		EtcdWatchEnable: true,
+		EtcdEndpoints:   userMetaAddrsInContainer,
+		EtcdWatchPrefix: "/fake-job/test/",
+	}
+	cfgBytes, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	fakeJobCfg := &fakeJobConfig{
+		etcdEndpoints: userMetaAddrs, // reuse user meta KV endpoints
+		workerCount:   cfg.WorkerCount,
+		keyPrefix:     cfg.EtcdWatchPrefix,
+	}
+	cli, err := NewUTCli(ctx, masterAddrs, userMetaAddrs, fakeJobCfg)
+	require.NoError(t, err)
+
+	jobID, err := cli.createJob(ctx, pb.JobType_FakeJob, cfgBytes)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		// check tick increases to ensure all workers are online
+		targetTick := int64(20)
+		for jobIdx := 0; jobIdx < cfg.WorkerCount; jobIdx++ {
+			err := cli.checkFakeJobTick(ctx, jobID, jobIdx, targetTick)
+			if err != nil {
+				log.L().Warn("check fake job tick failed", zap.Error(err))
+				return false
+			}
+		}
+		return true
+	}, time.Second*30, time.Second)
+
+	sourceUpdateCount := 10
+	sourceValue := "value"
+	for i := 0; i < sourceUpdateCount; i++ {
+		for j := 0; j < cfg.WorkerCount; j++ {
+			err := cli.updateFakeJobKey(ctx, j, sourceValue)
+			require.NoError(t, err)
+		}
+	}
+
+	require.Eventually(t, func() bool {
+		for jobIdx := 0; jobIdx < cfg.WorkerCount; jobIdx++ {
+			err := cli.checkFakeJobKey(ctx, jobID, jobIdx, sourceUpdateCount, sourceValue)
+			if err != nil {
+				log.L().Warn("check fake job failed", zap.Error(err))
+				return false
+			}
+		}
+		return true
+	}, time.Second*30, time.Second)
+
+	err = cli.pauseJob(ctx, jobID)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		stopped, err := cli.checkJobStatus(ctx, jobID, pb.QueryJobResponse_stopped)
+		return err == nil && stopped
+	}, time.Second*30, time.Second)
+}

--- a/test/e2e/e2e_node_chaos_test.go
+++ b/test/e2e/e2e_node_chaos_test.go
@@ -26,7 +26,7 @@ func TestNodeFailure(t *testing.T) {
 	ctx := context.Background()
 	cfg := &fake.Config{
 		JobName:     "test-node-failure",
-		WorkerCount: 5,
+		WorkerCount: 4,
 		// use a large enough target tick to ensure the fake job long running
 		TargetTick:      10000000,
 		EtcdWatchEnable: true,
@@ -58,7 +58,7 @@ func TestNodeFailure(t *testing.T) {
 			}
 		}
 		return true
-	}, time.Second*30, time.Second)
+	}, time.Second*60, time.Second*2)
 
 	sourceUpdateCount := 10
 	sourceValue := "value"
@@ -78,7 +78,7 @@ func TestNodeFailure(t *testing.T) {
 			}
 		}
 		return true
-	}, time.Second*30, time.Second)
+	}, time.Second*60, time.Second*2)
 
 	err = cli.PauseJob(ctx, jobID)
 	require.NoError(t, err)
@@ -94,5 +94,5 @@ func TestNodeFailure(t *testing.T) {
 			return false
 		}
 		return true
-	}, time.Second*30, time.Second)
+	}, time.Second*60, time.Second*2)
 }

--- a/test/e2e/e2e_node_chaos_test.go
+++ b/test/e2e/e2e_node_chaos_test.go
@@ -3,175 +3,17 @@ package e2e_test
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/stretchr/testify/require"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.uber.org/zap"
-	"google.golang.org/grpc"
 
-	"github.com/hanfei1991/microcosm/client"
 	"github.com/hanfei1991/microcosm/lib/fake"
 	"github.com/hanfei1991/microcosm/pb"
-	"github.com/hanfei1991/microcosm/pkg/meta/kvclient"
-	"github.com/hanfei1991/microcosm/pkg/meta/metaclient"
-	"github.com/hanfei1991/microcosm/pkg/tenant"
+	"github.com/hanfei1991/microcosm/test/e2e"
 )
-
-type utCli struct {
-	// used to operate with server master, such as submit job
-	masterCli client.MasterClient
-	// used to query metadata which is stored from business logic
-	metaCli metaclient.KVClient
-	// used to write to etcd to simulate the business of fake job, this etcd client
-	// reuses the endpoints of user meta KV.
-	fakeJobCli *clientv3.Client
-	fakeJobCfg *fakeJobConfig
-}
-
-type fakeJobConfig struct {
-	etcdEndpoints []string
-	workerCount   int
-	keyPrefix     string
-}
-
-func NewUTCli(
-	ctx context.Context, masterAddrs, userMetaAddrs []string, cfg *fakeJobConfig,
-) (*utCli, error) {
-	masterCli, err := client.NewMasterClient(ctx, masterAddrs)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	conf := metaclient.StoreConfigParams{Endpoints: userMetaAddrs}
-	userRawKVClient, err := kvclient.NewKVClient(&conf)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	metaCli := kvclient.NewPrefixKVClient(userRawKVClient, tenant.DefaultUserTenantID)
-
-	fakeJobCli, err := clientv3.New(clientv3.Config{
-		Endpoints:   userMetaAddrs,
-		Context:     ctx,
-		DialTimeout: 3 * time.Second,
-		DialOptions: []grpc.DialOption{},
-	})
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return &utCli{
-		masterCli:  masterCli,
-		metaCli:    metaCli,
-		fakeJobCli: fakeJobCli,
-		fakeJobCfg: cfg,
-	}, nil
-}
-
-func (cli *utCli) createJob(ctx context.Context, tp pb.JobType, config []byte) (string, error) {
-	req := &pb.SubmitJobRequest{Tp: tp, Config: config}
-	resp, err := cli.masterCli.SubmitJob(ctx, req)
-	if err != nil {
-		return "", err
-	}
-	if resp.Err != nil {
-		return "", errors.New(resp.Err.String())
-	}
-	return resp.JobIdStr, nil
-}
-
-func (cli *utCli) pauseJob(ctx context.Context, jobID string) error {
-	req := &pb.PauseJobRequest{JobIdStr: jobID}
-	resp, err := cli.masterCli.PauseJob(ctx, req)
-	if err != nil {
-		return err
-	}
-	if resp.Err != nil {
-		return errors.New(resp.Err.String())
-	}
-	return nil
-}
-
-func (cli *utCli) checkJobStatus(
-	ctx context.Context, jobID string, expectedStatus pb.QueryJobResponse_JobStatus,
-) (bool, error) {
-	req := &pb.QueryJobRequest{JobId: jobID}
-	resp, err := cli.masterCli.QueryJob(ctx, req)
-	if err != nil {
-		return false, err
-	}
-	if resp.Err != nil {
-		return false, errors.New(resp.Err.String())
-	}
-	return resp.Status == expectedStatus, nil
-}
-
-func (cli *utCli) updateFakeJobKey(ctx context.Context, id int, value string) error {
-	key := fmt.Sprintf("%s%d", cli.fakeJobCfg.keyPrefix, id)
-	_, err := cli.fakeJobCli.Put(ctx, key, value)
-	return errors.Trace(err)
-}
-
-func (cli *utCli) getFakeJobCheckpoint(
-	ctx context.Context, masterID string, jobIndex int,
-) (*fake.Checkpoint, error) {
-	ckptKey := fake.CheckpointKey(masterID)
-	resp, metaErr := cli.metaCli.Get(ctx, ckptKey)
-	if metaErr != nil {
-		return nil, errors.New(metaErr.Error())
-	}
-	if len(resp.Kvs) == 0 {
-		return nil, errors.New("no checkpoint found")
-	}
-	checkpoint := &fake.Checkpoint{}
-	err := json.Unmarshal(resp.Kvs[0].Value, checkpoint)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return checkpoint, nil
-}
-
-func (cli *utCli) checkFakeJobTick(
-	ctx context.Context, masterID string, jobIndex int, target int64,
-) error {
-	ckpt, err := cli.getFakeJobCheckpoint(ctx, masterID, jobIndex)
-	if err != nil {
-		return err
-	}
-	if tick, ok := ckpt.Ticks[jobIndex]; !ok {
-		return errors.Errorf("job %d not found in checkpoint %v", jobIndex, ckpt)
-	} else {
-		if tick < target {
-			return errors.Errorf("tick %d not reaches target %d", tick, target)
-		}
-	}
-	return nil
-}
-
-func (cli *utCli) checkFakeJobKey(
-	ctx context.Context, masterID string, jobIndex int, expectedMvcc int, expectedValue string,
-) error {
-	checkpoint, err := cli.getFakeJobCheckpoint(ctx, masterID, jobIndex)
-	if err != nil {
-		return err
-	}
-	if ckpt, ok := checkpoint.EtcdCheckpoints[jobIndex]; !ok {
-		return errors.Errorf("job %d not found in checkpoint %v", jobIndex, checkpoint)
-	} else {
-		if ckpt.Value != expectedValue {
-			return errors.Errorf("value not equals, expected: %s, actual: %s", expectedValue, ckpt.Value)
-		}
-		if ckpt.Mvcc != expectedMvcc {
-			return errors.Errorf("mvcc not equals, expected: %d, actual: %d", expectedMvcc, ckpt.Mvcc)
-		}
-	}
-
-	return nil
-}
 
 func TestNodeFailure(t *testing.T) {
 	// TODO: make the following variables configurable
@@ -194,22 +36,22 @@ func TestNodeFailure(t *testing.T) {
 	cfgBytes, err := json.Marshal(cfg)
 	require.NoError(t, err)
 
-	fakeJobCfg := &fakeJobConfig{
-		etcdEndpoints: userMetaAddrs, // reuse user meta KV endpoints
-		workerCount:   cfg.WorkerCount,
-		keyPrefix:     cfg.EtcdWatchPrefix,
+	fakeJobCfg := &e2e.FakeJobConfig{
+		EtcdEndpoints: userMetaAddrs, // reuse user meta KV endpoints
+		WorkerCount:   cfg.WorkerCount,
+		KeyPrefix:     cfg.EtcdWatchPrefix,
 	}
-	cli, err := NewUTCli(ctx, masterAddrs, userMetaAddrs, fakeJobCfg)
+	cli, err := e2e.NewUTCli(ctx, masterAddrs, userMetaAddrs, fakeJobCfg)
 	require.NoError(t, err)
 
-	jobID, err := cli.createJob(ctx, pb.JobType_FakeJob, cfgBytes)
+	jobID, err := cli.CreateJob(ctx, pb.JobType_FakeJob, cfgBytes)
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
 		// check tick increases to ensure all workers are online
 		targetTick := int64(20)
 		for jobIdx := 0; jobIdx < cfg.WorkerCount; jobIdx++ {
-			err := cli.checkFakeJobTick(ctx, jobID, jobIdx, targetTick)
+			err := cli.CheckFakeJobTick(ctx, jobID, jobIdx, targetTick)
 			if err != nil {
 				log.L().Warn("check fake job tick failed", zap.Error(err))
 				return false
@@ -222,14 +64,14 @@ func TestNodeFailure(t *testing.T) {
 	sourceValue := "value"
 	for i := 0; i < sourceUpdateCount; i++ {
 		for j := 0; j < cfg.WorkerCount; j++ {
-			err := cli.updateFakeJobKey(ctx, j, sourceValue)
+			err := cli.UpdateFakeJobKey(ctx, j, sourceValue)
 			require.NoError(t, err)
 		}
 	}
 
 	require.Eventually(t, func() bool {
 		for jobIdx := 0; jobIdx < cfg.WorkerCount; jobIdx++ {
-			err := cli.checkFakeJobKey(ctx, jobID, jobIdx, sourceUpdateCount, sourceValue)
+			err := cli.CheckFakeJobKey(ctx, jobID, jobIdx, sourceUpdateCount, sourceValue)
 			if err != nil {
 				log.L().Warn("check fake job failed", zap.Error(err))
 				return false
@@ -238,11 +80,19 @@ func TestNodeFailure(t *testing.T) {
 		return true
 	}, time.Second*30, time.Second)
 
-	err = cli.pauseJob(ctx, jobID)
+	err = cli.PauseJob(ctx, jobID)
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		stopped, err := cli.checkJobStatus(ctx, jobID, pb.QueryJobResponse_stopped)
-		return err == nil && stopped
+		stopped, err := cli.CheckJobStatus(ctx, jobID, pb.QueryJobResponse_stopped)
+		if err != nil {
+			log.L().Warn("check job status failed", zap.Error(err))
+			return false
+		}
+		if !stopped {
+			log.L().Info("job is not stopped")
+			return false
+		}
+		return true
 	}, time.Second*30, time.Second)
 }

--- a/test/e2e/e2e_test_cli.go
+++ b/test/e2e/e2e_test_cli.go
@@ -143,7 +143,7 @@ func (cli *utCli) CheckFakeJobTick(
 		return errors.Errorf("job %d not found in checkpoint %v", jobIndex, ckpt)
 	}
 	if tick < target {
-		return errors.Errorf("tick %d not reaches target %d", tick, target)
+		return errors.Errorf("tick %d not reaches target %d, checkpoint %v", tick, target, ckpt)
 	}
 	return nil
 }
@@ -160,10 +160,14 @@ func (cli *utCli) CheckFakeJobKey(
 		return errors.Errorf("job %d not found in checkpoint %v", jobIndex, checkpoint)
 	}
 	if ckpt.Value != expectedValue {
-		return errors.Errorf("value not equals, expected: '%s', actual: '%s'", expectedValue, ckpt.Value)
+		return errors.Errorf(
+			"value not equals, expected: '%s', actual: '%s', checkpoint %v",
+			expectedValue, ckpt.Value, ckpt)
 	}
 	if ckpt.Mvcc != expectedMvcc {
-		return errors.Errorf("mvcc not equals, expected: '%d', actual: '%d'", expectedMvcc, ckpt.Mvcc)
+		return errors.Errorf(
+			"mvcc not equals, expected: '%d', actual: '%d', checkpoint %v",
+			expectedMvcc, ckpt.Mvcc, ckpt)
 	}
 
 	return nil

--- a/test/e2e/e2e_test_cli.go
+++ b/test/e2e/e2e_test_cli.go
@@ -1,0 +1,170 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/pingcap/errors"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"google.golang.org/grpc"
+
+	"github.com/hanfei1991/microcosm/client"
+	"github.com/hanfei1991/microcosm/lib/fake"
+	"github.com/hanfei1991/microcosm/pb"
+	"github.com/hanfei1991/microcosm/pkg/meta/kvclient"
+	"github.com/hanfei1991/microcosm/pkg/meta/metaclient"
+	"github.com/hanfei1991/microcosm/pkg/tenant"
+)
+
+type utCli struct {
+	// used to operate with server master, such as submit job
+	masterCli client.MasterClient
+	// used to query metadata which is stored from business logic
+	metaCli metaclient.KVClient
+	// used to write to etcd to simulate the business of fake job, this etcd client
+	// reuses the endpoints of user meta KV.
+	fakeJobCli *clientv3.Client
+	fakeJobCfg *FakeJobConfig
+}
+
+type FakeJobConfig struct {
+	EtcdEndpoints []string
+	WorkerCount   int
+	KeyPrefix     string
+}
+
+func NewUTCli(
+	ctx context.Context, masterAddrs, userMetaAddrs []string, cfg *FakeJobConfig,
+) (*utCli, error) {
+	masterCli, err := client.NewMasterClient(ctx, masterAddrs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	conf := metaclient.StoreConfigParams{Endpoints: userMetaAddrs}
+	userRawKVClient, err := kvclient.NewKVClient(&conf)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	metaCli := kvclient.NewPrefixKVClient(userRawKVClient, tenant.DefaultUserTenantID)
+
+	fakeJobCli, err := clientv3.New(clientv3.Config{
+		Endpoints:   userMetaAddrs,
+		Context:     ctx,
+		DialTimeout: 3 * time.Second,
+		DialOptions: []grpc.DialOption{},
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return &utCli{
+		masterCli:  masterCli,
+		metaCli:    metaCli,
+		fakeJobCli: fakeJobCli,
+		fakeJobCfg: cfg,
+	}, nil
+}
+
+func (cli *utCli) CreateJob(ctx context.Context, tp pb.JobType, config []byte) (string, error) {
+	req := &pb.SubmitJobRequest{Tp: tp, Config: config}
+	resp, err := cli.masterCli.SubmitJob(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	if resp.Err != nil {
+		return "", errors.New(resp.Err.String())
+	}
+	return resp.JobIdStr, nil
+}
+
+func (cli *utCli) PauseJob(ctx context.Context, jobID string) error {
+	req := &pb.PauseJobRequest{JobIdStr: jobID}
+	resp, err := cli.masterCli.PauseJob(ctx, req)
+	if err != nil {
+		return err
+	}
+	if resp.Err != nil {
+		return errors.New(resp.Err.String())
+	}
+	return nil
+}
+
+func (cli *utCli) CheckJobStatus(
+	ctx context.Context, jobID string, expectedStatus pb.QueryJobResponse_JobStatus,
+) (bool, error) {
+	req := &pb.QueryJobRequest{JobId: jobID}
+	resp, err := cli.masterCli.QueryJob(ctx, req)
+	if err != nil {
+		return false, err
+	}
+	if resp.Err != nil {
+		return false, errors.New(resp.Err.String())
+	}
+	return resp.Status == expectedStatus, nil
+}
+
+func (cli *utCli) UpdateFakeJobKey(ctx context.Context, id int, value string) error {
+	key := fmt.Sprintf("%s%d", cli.fakeJobCfg.KeyPrefix, id)
+	_, err := cli.fakeJobCli.Put(ctx, key, value)
+	return errors.Trace(err)
+}
+
+func (cli *utCli) getFakeJobCheckpoint(
+	ctx context.Context, masterID string, jobIndex int,
+) (*fake.Checkpoint, error) {
+	ckptKey := fake.CheckpointKey(masterID)
+	resp, metaErr := cli.metaCli.Get(ctx, ckptKey)
+	if metaErr != nil {
+		return nil, errors.New(metaErr.Error())
+	}
+	if len(resp.Kvs) == 0 {
+		return nil, errors.New("no checkpoint found")
+	}
+	checkpoint := &fake.Checkpoint{}
+	err := json.Unmarshal(resp.Kvs[0].Value, checkpoint)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return checkpoint, nil
+}
+
+func (cli *utCli) CheckFakeJobTick(
+	ctx context.Context, masterID string, jobIndex int, target int64,
+) error {
+	ckpt, err := cli.getFakeJobCheckpoint(ctx, masterID, jobIndex)
+	if err != nil {
+		return err
+	}
+	tick, ok := ckpt.Ticks[jobIndex]
+	if !ok {
+		return errors.Errorf("job %d not found in checkpoint %v", jobIndex, ckpt)
+	}
+	if tick < target {
+		return errors.Errorf("tick %d not reaches target %d", tick, target)
+	}
+	return nil
+}
+
+func (cli *utCli) CheckFakeJobKey(
+	ctx context.Context, masterID string, jobIndex int, expectedMvcc int, expectedValue string,
+) error {
+	checkpoint, err := cli.getFakeJobCheckpoint(ctx, masterID, jobIndex)
+	if err != nil {
+		return err
+	}
+	ckpt, ok := checkpoint.EtcdCheckpoints[jobIndex]
+	if !ok {
+		return errors.Errorf("job %d not found in checkpoint %v", jobIndex, checkpoint)
+	}
+	if ckpt.Value != expectedValue {
+		return errors.Errorf("value not equals, expected: '%s', actual: '%s'", expectedValue, ckpt.Value)
+	}
+	if ckpt.Mvcc != expectedMvcc {
+		return errors.Errorf("mvcc not equals, expected: '%d', actual: '%d'", expectedMvcc, ckpt.Mvcc)
+	}
+
+	return nil
+}

--- a/test/e2e/e2e_test_cli.go
+++ b/test/e2e/e2e_test_cli.go
@@ -162,12 +162,12 @@ func (cli *utCli) CheckFakeJobKey(
 	if ckpt.Value != expectedValue {
 		return errors.Errorf(
 			"value not equals, expected: '%s', actual: '%s', checkpoint %v",
-			expectedValue, ckpt.Value, ckpt)
+			expectedValue, ckpt.Value, checkpoint)
 	}
 	if ckpt.Mvcc != expectedMvcc {
 		return errors.Errorf(
 			"mvcc not equals, expected: '%d', actual: '%d', checkpoint %v",
-			expectedMvcc, ckpt.Mvcc, ckpt)
+			expectedMvcc, ckpt.Mvcc, checkpoint)
 	}
 
 	return nil


### PR DESCRIPTION
The first part to add node failure test, this PR adds a new feature in fake job.
**Note the real node failure test will be added in next PR.**

- Add there more configurations in fake job config, if `etcd-watch-enable` is true, the fake worker will watch the key of `` etcd-watch-prefix + worker-index ``, any changes will be recorded and increase a mvcc count. The checkpoint is recorded as following. With this feature, we can simulate more failover tests later.

```diff
{
    "job-name": "test-fake-job-2",
    "worker-count": 3,
    "target-tick": 60000,
+    "etcd-watch-enable": true,
+    "etcd-endpoints": ["127.0.0.1:12479"],
+    "etcd-watch-prefix": "/fake-demo/test-2/"
}
```

```go
{"ticks":{"0":24960,"1":24953,"2":24925},
"etcd-checkpoints":{"0":{"revision":701,"mvcc":1,"value":"0x001"},"1":{"revision":692,"mvcc":5,"value":"0x002"},"2":{"revision":695,"mvcc":1,"value":"oiu"}}}
```

- Fix wrong usage of `OnWorkerDispatched` callback in fake master.