### PR TITLE
executor: retry register when meeting MasterNotReady error

### DIFF
--- a/executor/server.go
+++ b/executor/server.go
@@ -542,6 +542,7 @@ func (s *Server) selfRegister(ctx context.Context) (err error) {
 		retry.WithMaxTries(15 /* fail after 33 seconds, TODO: make it configurable */),
 		retry.WithIsRetryableErr(func(err error) bool {
 			if err.Error() == pb.ErrorCode_MasterNotReady.String() {
+				log.L().Info("server master leader is not ready, retry later")
 				return true
 			}
 			return false

--- a/executor/server.go
+++ b/executor/server.go
@@ -533,8 +533,6 @@ func (s *Server) selfRegister(ctx context.Context) (err error) {
 			return err2
 		}
 		if resp.Err != nil {
-			log.L().Info("register failed",
-				zap.String("error", resp.Err.Code.String()), zap.String("error2", pb.ErrorCode_MasterNotReady.String()))
 			return pcErrors.New(resp.Err.Code.String())
 		}
 		return nil

--- a/executor/server.go
+++ b/executor/server.go
@@ -5,8 +5,10 @@ import (
 	"strings"
 	"time"
 
+	pcErrors "github.com/pingcap/errors"
 	"github.com/pingcap/tiflow/dm/pkg/log"
 	p2pImpl "github.com/pingcap/tiflow/pkg/p2p"
+	"github.com/pingcap/tiflow/pkg/retry"
 	"github.com/pingcap/tiflow/pkg/security"
 	"github.com/pingcap/tiflow/pkg/tcpserver"
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
@@ -522,10 +524,36 @@ func (s *Server) selfRegister(ctx context.Context) (err error) {
 		Address:    s.cfg.AdvertiseAddr,
 		Capability: defaultCapability,
 	}
-	resp, err := s.masterClient.RegisterExecutor(ctx, registerReq, s.cfg.RPCTimeout)
+
+	var resp *pb.RegisterExecutorResponse
+	err = retry.Do(ctx, func() error {
+		var err2 error
+		resp, err2 = s.masterClient.RegisterExecutor(ctx, registerReq, s.cfg.RPCTimeout)
+		if err2 != nil {
+			return err2
+		}
+		if resp.Err != nil {
+			log.L().Info("register failed",
+				zap.String("error", resp.Err.Code.String()), zap.String("error2", pb.ErrorCode_MasterNotReady.String()))
+			return pcErrors.New(resp.Err.Code.String())
+		}
+		return nil
+	},
+		retry.WithBackoffBaseDelay(200 /* 200 ms */),
+		retry.WithBackoffMaxDelay(3000 /* 3 seconds */),
+		retry.WithMaxTries(15 /* fail after 33 seconds, TODO: make it configurable */),
+		retry.WithIsRetryableErr(func(err error) bool {
+			if err.Error() == pb.ErrorCode_MasterNotReady.String() {
+				return true
+			}
+			return false
+		}),
+	)
+
 	if err != nil {
-		return err
+		return
 	}
+
 	s.info = &model.NodeInfo{
 		Type:       model.NodeTypeExecutor,
 		ID:         model.ExecutorID(resp.ExecutorId),


### PR DESCRIPTION
Close #352 

The root cause is executor register itself to server master before server master leader is ready, the executor doesn't handle `MasterNotReady` error and records an empty executor ID.

In later heartbeat request from executor it contains an empty executor ID.

TODO:
- [x] Add a unit test.