### PR TITLE
fake(engine): worker could be nil in worker list

### DIFF
--- a/lib/fake/fake_master.go
+++ b/lib/fake/fake_master.go
@@ -369,6 +369,9 @@ func (m *Master) OnWorkerOnline(worker lib.WorkerHandle) error {
 func (m *Master) OnWorkerOffline(worker lib.WorkerHandle, reason error) error {
 	index := -1
 	for i, handle := range m.workerList {
+		if handle == nil {
+			continue
+		}
 		if handle.ID() == worker.ID() {
 			index = i
 			break


### PR DESCRIPTION
Fix the following panic found in test, `workerList` in fake master is a pre-allocated slice with nil pointer.

```golang
2022-05-13T03:25:39.674244547Z [2022/05/13 03:25:39.674 +00:00] [INFO] [task_runner.go:231] ["Task Closed"] [id=83fb921c-6019-4b31-8671-3d2dc27caa2f] [] [runtime-task-count=3]
2022-05-13T03:25:39.676583676Z panic: runtime error: invalid memory address or nil pointer dereference
2022-05-13T03:25:39.676597377Z [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x411bf41]
2022-05-13T03:25:39.676601177Z
2022-05-13T03:25:39.676604077Z goroutine 1253 [running]:
2022-05-13T03:25:39.676607077Z github.com/hanfei1991/microcosm/lib/fake.(*Master).OnWorkerOffline(0xc0002e7380, {0x5733f68, 0xc001d93260}, {0x56ff5c0?, 0xc001d93248})
2022-05-13T03:25:39.676610277Z    /dataflow-engine/lib/fake/fake_master.go:372 +0x961
2022-05-13T03:25:39.676613777Z github.com/hanfei1991/microcosm/lib.(*jobMasterImplAsMasterImpl).OnWorkerOffline(0x37630aa?, {0x5733f68?, 0xc001d93260?}, {0x56ff5c0?, 0xc001d93248?})
2022-05-13T03:25:39.676616877Z    /dataflow-engine/lib/base_jobmaster.go:306 +0x35
2022-05-13T03:25:39.676627977Z github.com/hanfei1991/microcosm/lib.(*DefaultBaseMaster).doInit.func2({0xc002557ba0?, 0xc002557b58?}, {0x5733f68?, 0xc001d93260?}, {0x56ff5c0?, 0xc001d93248?})
2022-05-13T03:25:39.676631377Z    /dataflow-engine/lib/master.go:269 +0x45
2022-05-13T03:25:39.676634277Z github.com/hanfei1991/microcosm/lib/master.(*WorkerManager).Tick(0xc0011015f0, {0x572c7b8, 0xc001e018f0})
2022-05-13T03:25:39.676637277Z    /dataflow-engine/lib/master/worker_manager.go:301 +0x228
2022-05-13T03:25:39.676640277Z github.com/hanfei1991/microcosm/lib.(*DefaultBaseMaster).doPoll(0xc000d64dc0, {0x572c7b8, 0xc001e018f0})
2022-05-13T03:25:39.676652377Z    /dataflow-engine/lib/master.go:374 +0xa5
2022-05-13T03:25:39.676655677Z github.com/hanfei1991/microcosm/lib.(*DefaultBaseJobMaster).Poll(0xc000c4be60, {0x572c6a0?, 0xc000a8f200})
2022-05-13T03:25:39.676658577Z    /dataflow-engine/lib/base_jobmaster.go:146 +0xa5
2022-05-13T03:25:39.676661477Z github.com/hanfei1991/microcosm/executor/worker.(*taskEntry).EventLoop(0xc0016a33e0, {0x572c6a0, 0xc000a8f200})
2022-05-13T03:25:39.676664477Z    /dataflow-engine/executor/worker/task_runner.go:68 +0x114
2022-05-13T03:25:39.676667677Z github.com/hanfei1991/microcosm/executor/worker.(*TaskRunner).onNewTask.func3()
2022-05-13T03:25:39.676670577Z    /dataflow-engine/executor/worker/task_runner.go:251 +0x572
2022-05-13T03:25:39.676673678Z created by github.com/hanfei1991/microcosm/executor/worker.(*TaskRunner).onNewTask
2022-05-13T03:25:39.676676678Z    /dataflow-engine/executor/worker/task_runner.go:225 +0x5db
```