### PR TITLE
fake(engine): fix concurrent bug and clean handler on worker offline

### DIFF
--- a/lib/fake/fake_master.go
+++ b/lib/fake/fake_master.go
@@ -382,15 +382,18 @@ func (m *Master) OnWorkerOnline(worker lib.WorkerHandle) error {
 // OnWorkerOffline implements MasterImpl.OnWorkerOffline
 func (m *Master) OnWorkerOffline(worker lib.WorkerHandle, reason error) error {
 	index := -1
+	m.workerListMu.Lock()
 	for i, handle := range m.workerList {
 		if handle == nil {
 			continue
 		}
 		if handle.ID() == worker.ID() {
 			index = i
+			m.workerList[i] = nil
 			break
 		}
 	}
+	m.workerListMu.Unlock()
 	if index < 0 {
 		return errors.Errorf("worker(%s) is not found in worker list", worker.ID())
 	}


### PR DESCRIPTION
- worker list in fake master should be protected by workerListMu.
- Should remove the old handler when worker is offline.