### PR TITLE
ci(engine): enable two chaos mesh injections and add real test case

### DIFF
--- a/.github/workflows/dataflow_engine_chaos.yaml
+++ b/.github/workflows/dataflow_engine_chaos.yaml
@@ -211,7 +211,7 @@ jobs:
         run: |
           mkdir ./logs
           sudo cp -r -L /var/log/containers/. ./logs
-          sudo find /var/ -type f -regex '.*/(server-master|executor).log$' | sudo xargs -i cp {} ./logs || true
+          sudo find /var/ -type f -regex '.*/(server-master|executor)-[^/]*.log$' | sudo xargs -i cp {} ./logs || true
           sudo chown -R runner ./logs
 
       # Upload logs as artifact seems not stable, so we set `continue-on-error: true` here.

--- a/.github/workflows/dataflow_engine_chaos.yaml
+++ b/.github/workflows/dataflow_engine_chaos.yaml
@@ -23,8 +23,8 @@ jobs:
       matrix:
         chaos-obj:
           [
-            "pod-failure-dfe",
-            "pod-kill-dfe",
+            "pod-failure-dataflow",
+            "pod-kill-dataflow",
           ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -191,15 +191,15 @@ jobs:
           kubectl get -f $GITHUB_WORKSPACE/chaos/manifests/cases.yaml
           kubectl describe -f $GITHUB_WORKSPACE/chaos/manifests/cases.yaml
 
-      # - name: Encode chaos-mesh action
-      #   run: |
-      #     echo CFG_BASE64=$(base64 -w 0 $GITHUB_WORKSPACE/chaos/manifests/${{ matrix.chaos-obj }}.yaml) >> $GITHUB_ENV
+      - name: Encode chaos-mesh action
+        run: |
+          echo CFG_BASE64=$(base64 -w 0 $GITHUB_WORKSPACE/chaos/manifests/${{ matrix.chaos-obj }}.yaml) >> $GITHUB_ENV
 
-      # - name: Run chaos mesh action
-      #   uses: chaos-mesh/chaos-mesh-action@master
-      #   env:
-      #     CFG_BASE64: ${{ env.CFG_BASE64 }}
-      #     CHAOS_MESH_VERSION: v1.0.0
+      - name: Run chaos mesh action
+        uses: chaos-mesh/chaos-mesh-action@master
+        env:
+          CFG_BASE64: ${{ env.CFG_BASE64 }}
+          CHAOS_MESH_VERSION: v1.0.0
 
       # check whether complete with 1m * 20 times.
       - name: Wait for chaos test case complete

--- a/.github/workflows/dataflow_engine_chaos.yaml
+++ b/.github/workflows/dataflow_engine_chaos.yaml
@@ -211,7 +211,7 @@ jobs:
         run: |
           mkdir ./logs
           sudo cp -r -L /var/log/containers/. ./logs
-          sudo find /var/ -type f -regex '.*/(server-master|executor)-[^/]*.log$' | sudo xargs -i cp {} ./logs || true
+          sudo find /var/ -type f | grep -E '.*/(server-master|executor)-[^/]*.log$' | sudo xargs -i cp {} ./logs || true
           sudo chown -R runner ./logs
 
       # Upload logs as artifact seems not stable, so we set `continue-on-error: true` here.

--- a/chaos/cases/config.go
+++ b/chaos/cases/config.go
@@ -22,8 +22,10 @@ import (
 type config struct {
 	*flag.FlagSet `toml:"-" yaml:"-" json:"-"`
 
-	MasterAddr string        `toml:"master-addr" yaml:"master-addr" json:"master-addr"`
-	Duration   time.Duration `toml:"duration" yaml:"duration" json:"duration"`
+	MasterAddr string `toml:"master-addr" yaml:"master-addr" json:"master-addr"`
+	// reuse user metastore currently
+	EtcdAddr string        `toml:"etcd-addr" yaml:"etcd-addr" json:"etcd-addr"`
+	Duration time.Duration `toml:"duration" yaml:"duration" json:"duration"`
 
 	MasterCount int `toml:"master-count" yaml:"master-count" json:"master-count"`
 	WorkerCount int `toml:"worker-count" yaml:"worker-count" json:"worker-count"`
@@ -36,6 +38,7 @@ func newConfig() *config {
 	fs := cfg.FlagSet
 
 	fs.StringVar(&cfg.MasterAddr, "master-addr", "server-master:10240", "address of server-master")
+	fs.StringVar(&cfg.EtcdAddr, "etcd-addr", "metastore:12479", "address of etcd server(used by fake job)")
 	fs.DurationVar(&cfg.Duration, "duration", 20*time.Minute, "duration of cases running")
 
 	fs.IntVar(&cfg.MasterCount, "master-count", 3, "expect count of server-master")

--- a/chaos/cases/fake_job_case.go
+++ b/chaos/cases/fake_job_case.go
@@ -88,7 +88,7 @@ func updateKeyAndCheck(
 			return err
 		}
 	}
-	finished := util.WaitSomething(40, time.Second*3, func() bool {
+	finished := util.WaitSomething(60, time.Second*5, func() bool {
 		for jobIdx := 0; jobIdx < workerCount; jobIdx++ {
 			err := cli.CheckFakeJobKey(ctx, jobID, jobIdx, expectedMvcc, updateValue)
 			if err != nil {

--- a/chaos/cases/fake_job_case.go
+++ b/chaos/cases/fake_job_case.go
@@ -88,7 +88,7 @@ func updateKeyAndCheck(
 			return err
 		}
 	}
-	finished := util.WaitSomething(20, time.Second*3, func() bool {
+	finished := util.WaitSomething(40, time.Second*3, func() bool {
 		for jobIdx := 0; jobIdx < workerCount; jobIdx++ {
 			err := cli.CheckFakeJobKey(ctx, jobID, jobIdx, expectedMvcc, updateValue)
 			if err != nil {

--- a/chaos/cases/fake_job_case.go
+++ b/chaos/cases/fake_job_case.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/hanfei1991/microcosm/lib/fake"
+	"github.com/hanfei1991/microcosm/pb"
+	"github.com/hanfei1991/microcosm/test/e2e"
+	"github.com/pingcap/tiflow/dm/pkg/log"
+	"github.com/pingcap/tiflow/pkg/util"
+	"go.uber.org/zap"
+)
+
+func runFakeJobCase(ctx context.Context, cfg *config) error {
+	serverMasterEndpoints := []string{cfg.MasterAddr}
+	etcdEndpoints := []string{cfg.EtcdAddr}
+
+	jobCfg := &fake.Config{
+		JobName:     "fake-job-case",
+		WorkerCount: 8,
+		// use a large enough target tick to ensure the fake job long running
+		TargetTick:      10000000,
+		EtcdWatchEnable: true,
+		EtcdEndpoints:   etcdEndpoints,
+		EtcdWatchPrefix: "/fake-job/test/",
+	}
+	e2eCfg := &e2e.FakeJobConfig{
+		EtcdEndpoints: etcdEndpoints, // reuse user meta KV endpoints
+		WorkerCount:   jobCfg.WorkerCount,
+		KeyPrefix:     jobCfg.EtcdWatchPrefix,
+	}
+	cli, err := e2e.NewUTCli(ctx, serverMasterEndpoints, etcdEndpoints, e2eCfg)
+	if err != nil {
+		return err
+	}
+	revision, err := cli.GetRevision(ctx)
+	if err != nil {
+		return err
+	}
+	jobCfg.EtcdStartRevision = revision
+	cfgBytes, err := json.Marshal(jobCfg)
+	if err != nil {
+		return err
+	}
+
+	// create a fake job
+	jobID, err := cli.CreateJob(ctx, pb.JobType_FakeJob, cfgBytes)
+	if err != nil {
+		return err
+	}
+
+	// update upstream etcd, and check fake job works normally every 30 seconds
+	// run 20 times, about 10 minutes totally.
+	mvcc := 0
+	interval := 30 * time.Second
+	runTime := 20
+	for i := 0; i < runTime; i++ {
+		value := fmt.Sprintf("update-value-index-%d", i)
+		mvcc++
+		start := time.Now()
+		err := updateKeyAndCheck(ctx, cli, jobID, jobCfg.WorkerCount, value, mvcc)
+		if err != nil {
+			return err
+		}
+		duration := time.Since(start)
+		log.L().Info("update key and check test", zap.Int("round", i), zap.Duration("duration", duration))
+		if duration < interval {
+			time.Sleep(start.Add(interval).Sub(time.Now()))
+		}
+	}
+
+	log.L().Info("run fake job case successfully")
+
+	return nil
+}
+
+func updateKeyAndCheck(
+	ctx context.Context, cli *e2e.ChaosCli, jobID string, workerCount int,
+	updateValue string, expectedMvcc int,
+) error {
+	for i := 0; i < workerCount; i++ {
+		err := cli.UpdateFakeJobKey(ctx, i, updateValue)
+		if err != nil {
+			return err
+		}
+	}
+	finished := util.WaitSomething(20, time.Second*3, func() bool {
+		for jobIdx := 0; jobIdx < workerCount; jobIdx++ {
+			err := cli.CheckFakeJobKey(ctx, jobID, jobIdx, expectedMvcc, updateValue)
+			if err != nil {
+				log.L().Warn("check fail job failed", zap.Error(err))
+				return false
+			}
+		}
+		return true
+	})
+	if !finished {
+		return errors.New("wait fake job normally timeout")
+	}
+	return nil
+}

--- a/chaos/cases/main.go
+++ b/chaos/cases/main.go
@@ -50,7 +50,6 @@ func main() {
 	}
 
 	err = log.InitLogger(&log.Config{
-		File:  "chaos-case.log",
 		Level: "info",
 	})
 	if err != nil {
@@ -82,7 +81,7 @@ func main() {
 	}()
 
 	// run tests cases
-	err = runCases(ctx)
+	err = runCases(ctx, cfg)
 	if err != nil {
 		log.L().Error("run cases failed", zap.Error(err))
 		code = 2

--- a/chaos/manifests/conf/server-master.toml
+++ b/chaos/manifests/conf/server-master.toml
@@ -7,4 +7,4 @@ auth.user = "root"
 auth.passwd = ""
 
 [user-metastore-conf]
-endpoints = ["metastore-user-etcd-0.metastore:12479"]
+endpoints = ["metastore:12479"]

--- a/chaos/manifests/executor.yaml
+++ b/chaos/manifests/executor.yaml
@@ -56,6 +56,7 @@ spec:
             - "--advertise-addr=$(MY_POD_NAME).executor.$(MY_POD_NAMESPACE):10241"
             - "--join=server-master-0.server-master.$(MY_POD_NAMESPACE):10240,server-master-1.server-master.$(MY_POD_NAMESPACE):10240,server-master-2.server-master.$(MY_POD_NAMESPACE):10240"
             - "--config=/conf/executor.toml"
+            - "--log-file=/log/$(MY_POD_NAME).log"
           readinessProbe:
             httpGet:
               port: 10241

--- a/chaos/manifests/pod-failure-dataflow.yaml
+++ b/chaos/manifests/pod-failure-dataflow.yaml
@@ -1,0 +1,22 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: pod-failure-dataflow
+  labels:
+    app: pod-failure-dataflow
+spec:
+  action: pod-failure
+  mode: one
+  duration: "30s"
+  selector:
+    pods:
+      default: # default namespace
+        - server-master-0
+        - server-master-1
+        - server-master-2
+        - executor-0
+        - executor-1
+        - executor-2
+        - executor-3
+  scheduler:
+    cron: "@every 2m"

--- a/chaos/manifests/pod-kill-dataflow.yaml
+++ b/chaos/manifests/pod-kill-dataflow.yaml
@@ -1,0 +1,22 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: PodChaos
+metadata:
+  name: pod-kill-dataflow
+  labels:
+    app: pod-kill-dataflow
+spec:
+  action: pod-kill
+  mode: one
+  gracePeriod: 30
+  selector:
+    pods:
+      default: # default namespace
+        - server-master-0
+        - server-master-1
+        - server-master-2
+        - executor-0
+        - executor-1
+        - executor-2
+        - executor-3
+  scheduler:
+    cron: "@every 2m"

--- a/chaos/manifests/server-master.yaml
+++ b/chaos/manifests/server-master.yaml
@@ -65,6 +65,7 @@ spec:
             - "--advertise-peer-urls=http://$(MY_POD_NAME).server-master.$(MY_POD_NAMESPACE):10239"
             - "--initial-cluster=server-master-0=http://server-master-0.server-master.$(MY_POD_NAMESPACE):10239,server-master-1=http://server-master-1.server-master.$(MY_POD_NAMESPACE):10239,server-master-2=http://server-master-2.server-master.$(MY_POD_NAMESPACE):10239"
             - "--config=/conf/server-master.toml"
+            - "--log-file=/log/$(MY_POD_NAME).log"
   volumeClaimTemplates:
     - metadata:
         name: server-master-data

--- a/lib/fake/fake_master.go
+++ b/lib/fake/fake_master.go
@@ -414,6 +414,7 @@ func (m *Master) OnWorkerOffline(worker lib.WorkerHandle, reason error) error {
 		if ws.Checkpoint != nil {
 			workerCkpt.Revision = ws.Checkpoint.Revision
 			workerCkpt.MvccCount = ws.Checkpoint.MvccCount
+			workerCkpt.Value = ws.Checkpoint.Value
 		}
 	}
 	wcfg := m.genWorkerConfig(businessID, workerCkpt)

--- a/lib/fake/fake_master.go
+++ b/lib/fake/fake_master.go
@@ -42,9 +42,10 @@ type Config struct {
 	WorkerCount int    `json:"worker-count"`
 	TargetTick  int    `json:"target-tick"`
 
-	EtcdWatchEnable bool     `json:"etcd-watch-enable"`
-	EtcdEndpoints   []string `json:"etcd-endpoints"`
-	EtcdWatchPrefix string   `json:"etcd-watch-prefix"`
+	EtcdWatchEnable   bool     `json:"etcd-watch-enable"`
+	EtcdEndpoints     []string `json:"etcd-endpoints"`
+	EtcdWatchPrefix   string   `json:"etcd-watch-prefix"`
+	EtcdStartRevision int64    `json:"etcd-start-revision"`
 
 	InjectErrorInterval time.Duration `json:"inject-error-interval"`
 }
@@ -198,6 +199,8 @@ func (m *Master) createWorker(wcfg *WorkerConfig) error {
 func (m *Master) initWorkers() error {
 	m.workerListMu.Lock()
 	defer m.workerListMu.Unlock()
+	checkpoint := zeroWorkerCheckpoint()
+	checkpoint.Revision = m.config.EtcdStartRevision
 OUT:
 	for i, handle := range m.workerList {
 		if handle == nil {
@@ -206,7 +209,7 @@ OUT:
 					continue OUT
 				}
 			}
-			wcfg := m.genWorkerConfig(i, zeroWorkerCheckpoint())
+			wcfg := m.genWorkerConfig(i, checkpoint)
 			err := m.createWorker(wcfg)
 			if err != nil {
 				return err
@@ -274,6 +277,7 @@ func (m *Master) tickedCheckWorkers(ctx context.Context) error {
 				if etcdCkpt, ok := ckpt.Checkpoints[i]; ok {
 					workerCkpt.Revision = etcdCkpt.Revision
 					workerCkpt.MvccCount = etcdCkpt.MvccCount
+					workerCkpt.Value = etcdCkpt.Value
 				}
 				wcfg := m.genWorkerConfig(i, workerCkpt)
 				if err := m.createWorker(wcfg); err != nil {
@@ -383,21 +387,11 @@ func (m *Master) OnWorkerOnline(worker lib.WorkerHandle) error {
 
 // OnWorkerOffline implements MasterImpl.OnWorkerOffline
 func (m *Master) OnWorkerOffline(worker lib.WorkerHandle, reason error) error {
-	index := -1
 	m.workerListMu.Lock()
-	for i, handle := range m.workerList {
-		if handle == nil {
-			continue
-		}
-		if handle.ID() == worker.ID() {
-			index = i
-			m.workerList[i] = nil
-			break
-		}
-	}
+	businessID, ok := m.workerID2BusinessID[worker.ID()]
 	m.workerListMu.Unlock()
-	if index < 0 {
-		return errors.Errorf("worker(%s) is not found in worker list", worker.ID())
+	if !ok {
+		return errors.Errorf("worker(%s) is not found in business id map", worker.ID())
 	}
 
 	m.bStatus.Lock()
@@ -406,7 +400,7 @@ func (m *Master) OnWorkerOffline(worker lib.WorkerHandle, reason error) error {
 
 	if derrors.ErrWorkerFinish.Equal(reason) {
 		log.L().Info("FakeMaster: OnWorkerOffline: worker finished", zap.String("worker-id", worker.ID()))
-		m.finishedSet[worker.ID()] = index
+		m.finishedSet[worker.ID()] = businessID
 		return nil
 	}
 
@@ -422,7 +416,7 @@ func (m *Master) OnWorkerOffline(worker lib.WorkerHandle, reason error) error {
 			workerCkpt.MvccCount = ws.Checkpoint.MvccCount
 		}
 	}
-	wcfg := m.genWorkerConfig(index, workerCkpt)
+	wcfg := m.genWorkerConfig(businessID, workerCkpt)
 	m.workerListMu.Lock()
 	defer m.workerListMu.Unlock()
 	return m.createWorker(wcfg)

--- a/lib/fake/fake_worker.go
+++ b/lib/fake/fake_worker.go
@@ -243,10 +243,14 @@ watchLoop:
 		default:
 		}
 		opts := make([]clientv3.OpOption, 0)
-		if d.status.getEtcdCheckpoint().Revision > 0 {
-			opts = append(opts, clientv3.WithRev(d.status.getEtcdCheckpoint().Revision+1))
+		revision := d.status.getEtcdCheckpoint().Revision
+		if revision > 0 {
+			opts = append(opts, clientv3.WithRev(revision+1))
 		}
 		ch := cli.Watch(ctx, key, opts...)
+		log.L().Info("start to watch etcd", zap.String("key", key),
+			zap.Int64("revision", revision),
+			zap.Strings("endpoints", d.config.EtcdEndpoints))
 		for resp := range ch {
 			if resp.Err() != nil {
 				log.L().Warn("watch met error", zap.Error(resp.Err()))
@@ -283,6 +287,7 @@ func NewDummyWorker(
 		Checkpoint: &workerCheckpoint{
 			Revision:  wcfg.Checkpoint.Revision,
 			MvccCount: wcfg.Checkpoint.MvccCount,
+			Value:     wcfg.Checkpoint.Value,
 		},
 	}
 	return &dummyWorker{

--- a/test/e2e/e2e_test_cli.go
+++ b/test/e2e/e2e_test_cli.go
@@ -188,6 +188,15 @@ func (cli *ChaosCli) CheckFakeJobKey(
 	return nil
 }
 
+// GetRevision puts a key gets the latest revision of etcd cluster
+func (cli *ChaosCli) GetRevision(ctx context.Context) (int64, error) {
+	resp, err := cli.fakeJobCli.Put(ctx, "/chaos/gen_epoch/key", "/chaos/gen_epoch/value")
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	return resp.Header.Revision, nil
+}
+
 func runCmdHandleError(cmd *exec.Cmd) []byte {
 	log.L().Info("Start executing command", zap.String("cmd", cmd.String()))
 	bytes, err := cmd.Output()


### PR DESCRIPTION
Part 2 of #396 
- Add two chaos mesh injection.
- Add a simple fake job workload, quite similar to e2e node failure case.